### PR TITLE
[fix] issue_milestone 테이블 삭제

### DIFF
--- a/web-BE/sql/create-table.sql
+++ b/web-BE/sql/create-table.sql
@@ -1,3 +1,6 @@
+-- -----------------------------------------------------
+-- Schema IssueTracker
+-- -----------------------------------------------------
 CREATE SCHEMA IF NOT EXISTS `IssueTracker` DEFAULT CHARACTER SET utf8 ;
 USE `IssueTracker` ;
 
@@ -14,6 +17,18 @@ ENGINE = InnoDB;
 
 
 -- -----------------------------------------------------
+-- Table `IssueTracker`.`Milestone`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `IssueTracker`.`Milestone` (
+  `milestone_id` INT NOT NULL AUTO_INCREMENT,
+  `title` VARCHAR(45) NOT NULL,
+  `due_date` DATE NOT NULL,
+  `content` TEXT NULL,
+  PRIMARY KEY (`milestone_id`))
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
 -- Table `IssueTracker`.`Issue`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `IssueTracker`.`Issue` (
@@ -22,7 +37,14 @@ CREATE TABLE IF NOT EXISTS `IssueTracker`.`Issue` (
   `write_time` TIMESTAMP NOT NULL,
   `title` VARCHAR(45) NOT NULL,
   `is_open` TINYINT NOT NULL,
-  PRIMARY KEY (`issue_id`))
+  `Milestone_milestone_id` INT NOT NULL,
+  PRIMARY KEY (`issue_id`),
+  INDEX `fk_Issue_Milestone1_idx` (`Milestone_milestone_id` ASC) ,
+  CONSTRAINT `fk_Issue_Milestone1`
+    FOREIGN KEY (`Milestone_milestone_id`)
+    REFERENCES `IssueTracker`.`Milestone` (`milestone_id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
 ENGINE = InnoDB;
 
 
@@ -38,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `IssueTracker`.`Comment` (
   `is_issue_content` TINYINT NOT NULL COMMENT '이슈의 본문에 해당하는 댓글인지 아니면 그냥 댓글인지를 나타내는 column',
   `Issue_issue_id` INT NOT NULL,
   PRIMARY KEY (`comment_id`, `Issue_issue_id`),
-  INDEX `fk_Comment_Issue_idx` (`Issue_issue_id` ASC) VISIBLE,
+  INDEX `fk_Comment_Issue_idx` (`Issue_issue_id` ASC) ,
   CONSTRAINT `fk_Comment_Issue`
     FOREIGN KEY (`Issue_issue_id`)
     REFERENCES `IssueTracker`.`Issue` (`issue_id`)
@@ -60,26 +82,14 @@ ENGINE = InnoDB;
 
 
 -- -----------------------------------------------------
--- Table `IssueTracker`.`Milestone`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `IssueTracker`.`Milestone` (
-  `milestone_id` INT NOT NULL AUTO_INCREMENT,
-  `title` VARCHAR(45) NOT NULL,
-  `due_date` DATE NOT NULL,
-  `content` TEXT NULL,
-  PRIMARY KEY (`milestone_id`))
-ENGINE = InnoDB;
-
-
--- -----------------------------------------------------
 -- Table `IssueTracker`.`Issue_Label`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `IssueTracker`.`Issue_Label` (
   `Label_label_id` INT NOT NULL,
   `Issue_issue_id` INT NOT NULL,
   PRIMARY KEY (`Label_label_id`, `Issue_issue_id`),
-  INDEX `fk_Label_has_Issue_Issue1_idx` (`Issue_issue_id` ASC) VISIBLE,
-  INDEX `fk_Label_has_Issue_Label1_idx` (`Label_label_id` ASC) VISIBLE,
+  INDEX `fk_Label_has_Issue_Issue1_idx` (`Issue_issue_id` ASC) ,
+  INDEX `fk_Label_has_Issue_Label1_idx` (`Label_label_id` ASC) ,
   CONSTRAINT `fk_Label_has_Issue_Label1`
     FOREIGN KEY (`Label_label_id`)
     REFERENCES `IssueTracker`.`Label` (`label_id`)
@@ -100,8 +110,8 @@ CREATE TABLE IF NOT EXISTS `IssueTracker`.`Assignee` (
   `Issue_issue_id` INT NOT NULL,
   `User_user_id` INT NOT NULL,
   PRIMARY KEY (`Issue_issue_id`, `User_user_id`),
-  INDEX `fk_Issue_has_User_User1_idx` (`User_user_id` ASC) VISIBLE,
-  INDEX `fk_Issue_has_User_Issue1_idx` (`Issue_issue_id` ASC) VISIBLE,
+  INDEX `fk_Issue_has_User_User1_idx` (`User_user_id` ASC) ,
+  INDEX `fk_Issue_has_User_Issue1_idx` (`Issue_issue_id` ASC) ,
   CONSTRAINT `fk_Issue_has_User_Issue1`
     FOREIGN KEY (`Issue_issue_id`)
     REFERENCES `IssueTracker`.`Issue` (`issue_id`)
@@ -110,28 +120,6 @@ CREATE TABLE IF NOT EXISTS `IssueTracker`.`Assignee` (
   CONSTRAINT `fk_Issue_has_User_User1`
     FOREIGN KEY (`User_user_id`)
     REFERENCES `IssueTracker`.`User` (`user_id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION)
-ENGINE = InnoDB;
-
-
--- -----------------------------------------------------
--- Table `IssueTracker`.`Issue_Milestone`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `IssueTracker`.`Issue_Milestone` (
-  `Milestone_milestone_id` INT NOT NULL,
-  `Issue_issue_id` INT NOT NULL,
-  PRIMARY KEY (`Milestone_milestone_id`, `Issue_issue_id`),
-  INDEX `fk_Milestone_has_Issue_Issue1_idx` (`Issue_issue_id` ASC) VISIBLE,
-  INDEX `fk_Milestone_has_Issue_Milestone1_idx` (`Milestone_milestone_id` ASC) VISIBLE,
-  CONSTRAINT `fk_Milestone_has_Issue_Milestone1`
-    FOREIGN KEY (`Milestone_milestone_id`)
-    REFERENCES `IssueTracker`.`Milestone` (`milestone_id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION,
-  CONSTRAINT `fk_Milestone_has_Issue_Issue1`
-    FOREIGN KEY (`Issue_issue_id`)
-    REFERENCES `IssueTracker`.`Issue` (`issue_id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
 ENGINE = InnoDB;


### PR DESCRIPTION
# issue_milestone 테이블 삭제
## 관련 이슈 및 위키
**위키** : [관련 위키](https://github.com/boostcamp-2020/IssueTracker-12/wiki/DB-ERD,--CRUD-API-%EA%B3%84%ED%9A%8D)
**이슈** : #7 
## 내용
 issue_milestone 테이블을 삭제했습니다.
## Why?
이슈 하나에 마일스톤이 하나만 등록이 되기 때문에 issue 테이블과 milestone 테이블의 관계를 1:N 관계로 바꾸어 M:N 관계일 때 필요했던 issue_milestone 테이블을 삭제했습니다.