### PR TITLE
[refactor] milestone API 수정

### DIFF
--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -8,7 +8,8 @@ module.exports = {
   // milestone
   insertMilestone:
     'INSERT INTO Milestone (title,due_date,content) VALUES (?,?,?);',
-  selectMilestone: 'SELECT milestone_id,title,due_date,content FROM Milestone;',
+  selectMilestone:
+    'SELECT milestone_id,title,date_format(due_date,"%Y-%m-%d") AS due_date,content FROM Milestone;',
   updateMilestone:
     'UPDATE Milestone SET title=?, due_date=?, content=? WHERE milestone_id=?;',
   deleteMilestone: 'DELETE FROM Milestone WHERE milestone_id=?;',

--- a/web-BE/models/milestone.js
+++ b/web-BE/models/milestone.js
@@ -4,7 +4,8 @@ const sql = require('../config/query');
 const milestoneModel = {
   insert: async (insertInfo) => {
     try {
-      connection.query(sql.insertMilestone, insertInfo);
+      const result = await connection.query(sql.insertMilestone, insertInfo);
+      return result[0].insertId;
     } catch (err) {
       console.error(err);
     }

--- a/web-BE/routes/api/milestone/controller.js
+++ b/web-BE/routes/api/milestone/controller.js
@@ -26,7 +26,7 @@ const milestoneController = {
       milestoneid, title, dueDate, content,
     } = req.body;
     try {
-      const updateInfo = [milestoneid, title, dueDate, content];
+      const updateInfo = [title, dueDate, content, milestoneid];
       milestoneModel.update(updateInfo);
       res.status(200).json({ message: '마일스톤 업데이트 완료' });
     } catch (err) {
@@ -35,7 +35,7 @@ const milestoneController = {
   },
   delete: (req, res) => {
     try {
-      milestoneModel.delete(parseInt(req.query.milestoneid));
+      milestoneModel.delete(parseInt(req.params.milestoneid));
       res.status(200).json({ message: '마일스톤 삭제 완료' });
     } catch (err) {
       res.status(500).json(err);

--- a/web-BE/routes/api/milestone/controller.js
+++ b/web-BE/routes/api/milestone/controller.js
@@ -1,12 +1,14 @@
 const milestoneModel = require('../../../models/milestone');
 
 const milestoneController = {
-  create: (req, res) => {
+  create: async (req, res) => {
     const { title, dueDate, content } = req.body;
     try {
       const insertInfo = [title, dueDate, content];
-      milestoneModel.insert(insertInfo);
-      res.status(200).json({ message: '마일스톤 생성 완료' });
+      const insertId = await milestoneModel.insert(insertInfo);
+      res
+        .status(200)
+        .json({ message: '마일스톤 생성 완료', insertId });
     } catch (err) {
       res.status(500).json(err);
     }

--- a/web-BE/routes/api/milestone/controller.js
+++ b/web-BE/routes/api/milestone/controller.js
@@ -26,7 +26,7 @@ const milestoneController = {
       milestoneid, title, dueDate, content,
     } = req.body;
     try {
-      const updateInfo = [milstoneid, title, dueDate, content];
+      const updateInfo = [milestoneid, title, dueDate, content];
       milestoneModel.update(updateInfo);
       res.status(200).json({ message: '마일스톤 업데이트 완료' });
     } catch (err) {

--- a/web-BE/routes/api/milestone/controller.js
+++ b/web-BE/routes/api/milestone/controller.js
@@ -22,10 +22,9 @@ const milestoneController = {
     }
   },
   update: (req, res) => {
-    const {
-      milestoneid, title, dueDate, content,
-    } = req.body;
+    const { title, dueDate, content } = req.body;
     try {
+      const milestoneid = parseInt(req.params.milestoneid);
       const updateInfo = [title, dueDate, content, milestoneid];
       milestoneModel.update(updateInfo);
       res.status(200).json({ message: '마일스톤 업데이트 완료' });

--- a/web-BE/routes/api/milestone/index.js
+++ b/web-BE/routes/api/milestone/index.js
@@ -3,7 +3,7 @@ const milestoneController = require('./controller');
 
 router.post('/', milestoneController.create);
 router.get('/', milestoneController.read);
-router.patch('/', milestoneController.update);
+router.put('/:milestoneid', milestoneController.update);
 router.delete('/:milestoneid', milestoneController.delete);
 
 module.exports = router;

--- a/web-BE/routes/api/milestone/index.js
+++ b/web-BE/routes/api/milestone/index.js
@@ -4,6 +4,6 @@ const milestoneController = require('./controller');
 router.post('/', milestoneController.create);
 router.get('/', milestoneController.read);
 router.patch('/', milestoneController.update);
-router.delete('/', milestoneController.delete);
+router.delete('/:milestoneid', milestoneController.delete);
 
 module.exports = router;


### PR DESCRIPTION
# 제목
milestone api 수정
## 관련 이슈 및 위키
#12 #13 #14 #15 

## 내용
> 7020f1c 
milestone이 milstone이라고 오타가 나 있어서 수정하였습니다. 👀
milestone 길어서 오타가 자주 나는 거 같아요.. ㅜㅜ push 전 오타 주의하겠습니다.

> c2abdf0
read할 때 date format이 아름답지 못해서 (날짜만 필요한데 시간이 포함되어 나와서..) 고민을 하다,
쿼리문으로도 데이트포맷을 정해서 가져올 수 있어 적용해보았습니다.
이럴 경우 select할 때 칼럼 명이 date_format(...)로 변경 되어 as 를 써서 변수를 따로 적용해주었습니다.

> 3509401
- update: sql에 들어가는 데이터 순서 변경하였습니다. (오류 초래해서..)
- delete: id를 path parameter로 작동하도록 변경하였습니다.

> b1b3ed9
- update: patch -> put 으로 변경하였습니다.
- update: id를 path parameter로 변경하였습니다.

> b22a9b2
- create 동작 이후 insertId를 반환하도록 하였습니다.

## Why?
- milestone은 path parameters로 관리하는 게 나아 기존 query 방식으로 동작하던 것을 변경하였습니다.
- 기존 `update`시 이름은 `patch` 였지만, `put`처럼 동작하였기에 put으로 변경하였습니다.
- 나중에 프론트에서 작업할 때 create이후 id를 리턴하는 게 좋을 것 같다는 팀원과의 회의 후에 반환하도록 하였습니다.