### PR TITLE
[feat] web-BE issue 관련 api 구현

### DIFF
--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -38,6 +38,7 @@ module.exports = {
   deleteIssueMilestone: 'UPDATE Issue SET milestone_id=NULL WHERE issue_id=?',
   // issue_label
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
+  deleteIssueLabel: 'DELETE FROM Issue_Label WHERE issue_id=? and label_id=?',
   selectIssueLabel:
     'select Label.label_id, Label.`name` as label_name, Label.description, Label.color from Issue_Label '
     + 'join Label on Issue_Label.label_id = Label.label_id WHERE Issue_Label.issue_id = ?',

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -20,6 +20,22 @@ module.exports = {
     'INSERT INTO Issue '
     + '(writer_id, write_time, title, is_open, milestone_id) '
     + 'VALUES((SELECT user_id from User WHERE username=?), ?, ?, 1, ?)',
+  selectIssue:
+    `SELECT
+      Issue.issue_id,
+      Issue.title,
+      Milestone.milestone_id,
+      Milestone.title as milestone_title,
+      Issue.write_time,
+      Issue.is_open,
+      \`User\`.user_id as writer_id,
+      \`User\`.username as writer
+    FROM Issue
+      LEFT JOIN Milestone ON Milestone.milestone_id = Issue.milestone_id
+      JOIN \`User\` ON Issue.writer_id = \`User\`.user_id`,
   // issue_label
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
+  selectIssueLabel:
+    'select Label.label_id, Label.`name` as label_name, Label.description, Label.color from Issue_Label '
+    + 'join Label on Issue_Label.label_id = Label.label_id WHERE Issue_Label.issue_id = ?',
 };

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -34,6 +34,7 @@ module.exports = {
       LEFT JOIN Milestone ON Milestone.milestone_id = Issue.milestone_id
       JOIN \`User\` ON Issue.writer_id = \`User\`.user_id`,
   updateIssueTitle: 'UPDATE Issue SET title=? WHERE issue_id=?',
+  insertIssueMilestone: 'UPDATE Issue SET milestone_id=? WHERE issue_id=?',
   // issue_label
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
   selectIssueLabel:

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -33,6 +33,7 @@ module.exports = {
     FROM Issue
       LEFT JOIN Milestone ON Milestone.milestone_id = Issue.milestone_id
       JOIN \`User\` ON Issue.writer_id = \`User\`.user_id`,
+  updateIssueTitle: 'UPDATE Issue SET title=? WHERE issue_id=?',
   // issue_label
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
   selectIssueLabel:

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -36,6 +36,7 @@ module.exports = {
   updateIssueTitle: 'UPDATE Issue SET title=? WHERE issue_id=?',
   insertIssueMilestone: 'UPDATE Issue SET milestone_id=? WHERE issue_id=?',
   deleteIssueMilestone: 'UPDATE Issue SET milestone_id=NULL WHERE issue_id=?',
+  updateIssueIsOpen: 'UPDATE Issue SET is_open=? WHERE issue_id=?',
   // issue_label
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
   deleteIssueLabel: 'DELETE FROM Issue_Label WHERE issue_id=? and label_id=?',

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -46,4 +46,7 @@ module.exports = {
   // Assignee
   insertAssignee: 'INSERT INTO Assignee(issue_id, user_id) VALUES (?, ?)',
   deleteAssignee: 'DELETE FROM Assignee WHERE issue_id=? and user_id=?',
+  selectAssignee:
+    'SELECT `User`.user_id, `User`.username, `User`.social from Assignee '
+    + 'JOIN `User` ON Assignee.user_id = `User`.user_id WHERE Assignee.issue_id=?',
 };

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -35,6 +35,7 @@ module.exports = {
       JOIN \`User\` ON Issue.writer_id = \`User\`.user_id`,
   updateIssueTitle: 'UPDATE Issue SET title=? WHERE issue_id=?',
   insertIssueMilestone: 'UPDATE Issue SET milestone_id=? WHERE issue_id=?',
+  deleteIssueMilestone: 'UPDATE Issue SET milestone_id=NULL WHERE issue_id=?',
   // issue_label
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
   selectIssueLabel:

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -18,8 +18,8 @@ module.exports = {
   // issue
   insertIssue:
     'INSERT INTO Issue '
-    + '(writer_id, write_time, title, is_open, milestone_id) '
-    + 'VALUES((SELECT user_id from User WHERE username=?), ?, ?, 1, ?)',
+    + '(writer_id, write_time, title, milestone_id) '
+    + 'VALUES((SELECT user_id from User WHERE username=?), ?, ?, ?)',
   selectIssue:
     `SELECT
       Issue.issue_id,
@@ -28,11 +28,11 @@ module.exports = {
       Milestone.title as milestone_title,
       Issue.write_time,
       Issue.is_open,
-      \`User\`.user_id as writer_id,
-      \`User\`.username as writer
+      User.user_id as writer_id,
+      User.username as writer
     FROM Issue
       LEFT JOIN Milestone ON Milestone.milestone_id = Issue.milestone_id
-      JOIN \`User\` ON Issue.writer_id = \`User\`.user_id`,
+      JOIN User ON Issue.writer_id = User.user_id`,
   updateIssueTitle: 'UPDATE Issue SET title=? WHERE issue_id=?',
   insertIssueMilestone: 'UPDATE Issue SET milestone_id=? WHERE issue_id=?',
   deleteIssueMilestone: 'UPDATE Issue SET milestone_id=NULL WHERE issue_id=?',
@@ -41,12 +41,12 @@ module.exports = {
   insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
   deleteIssueLabel: 'DELETE FROM Issue_Label WHERE issue_id=? and label_id=?',
   selectIssueLabel:
-    'select Label.label_id, Label.`name` as label_name, Label.description, Label.color from Issue_Label '
+    'select Label.label_id, Label.name as label_name, Label.description, Label.color from Issue_Label '
     + 'join Label on Issue_Label.label_id = Label.label_id WHERE Issue_Label.issue_id = ?',
   // Assignee
   insertAssignee: 'INSERT INTO Assignee(issue_id, user_id) VALUES (?, ?)',
   deleteAssignee: 'DELETE FROM Assignee WHERE issue_id=? and user_id=?',
   selectAssignee:
-    'SELECT `User`.user_id, `User`.username, `User`.social from Assignee '
-    + 'JOIN `User` ON Assignee.user_id = `User`.user_id WHERE Assignee.issue_id=?',
+    'SELECT User.user_id, User.username, User.social from Assignee '
+    + 'JOIN User ON Assignee.user_id = User.user_id WHERE Assignee.issue_id=?',
 };

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -43,4 +43,7 @@ module.exports = {
   selectIssueLabel:
     'select Label.label_id, Label.`name` as label_name, Label.description, Label.color from Issue_Label '
     + 'join Label on Issue_Label.label_id = Label.label_id WHERE Issue_Label.issue_id = ?',
+  // Assignee
+  insertAssignee: 'INSERT INTO Assignee(issue_id, user_id) VALUES (?, ?)',
+  deleteAssignee: 'DELETE FROM Assignee WHERE issue_id=? and user_id=?',
 };

--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -15,4 +15,11 @@ module.exports = {
   deleteMilestone: 'DELETE FROM Milestone WHERE milestone_id=?;',
   // user
   selectUser: 'SELECT user_id, username, social FROM User WHERE username=? and social=?',
+  // issue
+  insertIssue:
+    'INSERT INTO Issue '
+    + '(writer_id, write_time, title, is_open, milestone_id) '
+    + 'VALUES((SELECT user_id from User WHERE username=?), ?, ?, 1, ?)',
+  // issue_label
+  insertIssueLabel: 'INSERT INTO Issue_Label (issue_id, label_id) VALUES ?',
 };

--- a/web-BE/models/assignee.js
+++ b/web-BE/models/assignee.js
@@ -8,6 +8,10 @@ const assigneeModel = {
   delete: async (issueId, userId) => {
     await connection.query(sql.deleteAssignee, [issueId, userId]);
   },
+  select: async (issueId) => {
+    const [res] = await connection.query(sql.selectAssignee, [issueId]);
+    return res;
+  },
 };
 
 module.exports = assigneeModel;

--- a/web-BE/models/assignee.js
+++ b/web-BE/models/assignee.js
@@ -1,0 +1,13 @@
+const connection = require('../config/db_connection');
+const sql = require('../config/query');
+
+const assigneeModel = {
+  insert: async (issueId, userId) => {
+    await connection.query(sql.insertAssignee, [issueId, userId]);
+  },
+  delete: async (issueId, userId) => {
+    await connection.query(sql.deleteAssignee, [issueId, userId]);
+  },
+};
+
+module.exports = assigneeModel;

--- a/web-BE/models/issue.js
+++ b/web-BE/models/issue.js
@@ -1,0 +1,27 @@
+const createError = require('http-errors');
+const connection = require('../config/db_connection');
+const sql = require('../config/query');
+const issueLabelModel = require('./issue_label');
+
+const issueModel = {
+  insert: async ({
+    writer, title, milestone, writeTime, labelArr,
+  }) => {
+    const issueTableData = [writer, writeTime, title, milestone];
+    await connection.beginTransaction();
+    try {
+      const [res] = await connection.query(sql.insertIssue, issueTableData);
+      const { insertId: issueId } = res;
+      await issueLabelModel.insert(issueId, labelArr);
+      await connection.commit();
+      return issueId;
+    } catch (err) {
+      console.error(err);
+      connection.rollback();
+      // TODO: 에러처리 어떻게 할까
+      throw createError(500);
+    }
+  },
+};
+
+module.exports = issueModel;

--- a/web-BE/models/issue.js
+++ b/web-BE/models/issue.js
@@ -22,6 +22,19 @@ const issueModel = {
       throw createError(500);
     }
   },
+  select: async () => {
+    try {
+      const [issueArr] = await connection.query(sql.selectIssue);
+      const labelsOfIssue = await Promise.all(
+        issueArr.map((issue) => issueLabelModel.select(issue.issue_id)),
+      );
+      const issueWithLabels = issueArr.map((issue, i) => ({ ...issue, labels: labelsOfIssue[i] }));
+      return issueWithLabels;
+    } catch (err) {
+      console.error(err);
+      throw createError(500);
+    }
+  },
 };
 
 module.exports = issueModel;

--- a/web-BE/models/issue.js
+++ b/web-BE/models/issue.js
@@ -51,6 +51,14 @@ const issueModel = {
       throw createError(500);
     }
   },
+  deleteMilestone: async (issueId) => {
+    try {
+      await connection.query(sql.deleteIssueMilestone, [issueId]);
+    } catch (err) {
+      console.error(err);
+      throw createError(500);
+    }
+  },
 };
 
 module.exports = issueModel;

--- a/web-BE/models/issue.js
+++ b/web-BE/models/issue.js
@@ -42,7 +42,15 @@ const issueModel = {
       console.error(err);
       throw createError(500);
     }
-  }
+  },
+  insertMilestone: async (issueId, milestoneId) => {
+    try {
+      await connection.query(sql.insertIssueMilestone, [milestoneId, issueId]);
+    } catch (err) {
+      console.error(err);
+      throw createError(500);
+    }
+  },
 };
 
 module.exports = issueModel;

--- a/web-BE/models/issue.js
+++ b/web-BE/models/issue.js
@@ -35,6 +35,14 @@ const issueModel = {
       throw createError(500);
     }
   },
+  updateTitle: async (issueId, title) => {
+    try {
+      await connection.query(sql.updateIssueTitle, [title, issueId]);
+    } catch (err) {
+      console.error(err);
+      throw createError(500);
+    }
+  }
 };
 
 module.exports = issueModel;

--- a/web-BE/models/issue_label.js
+++ b/web-BE/models/issue_label.js
@@ -4,8 +4,12 @@ const sql = require('../config/query');
 const issueLabelModel = {
   insert: async (issueId, labelArr) => {
     const issueLabelData = labelArr.reduce((acc, curr) => [...acc, [issueId, curr]], []);
-    console.log('asdfsddfsef', issueLabelData);
     await connection.query(sql.insertIssueLabel, [issueLabelData]);
+  },
+  select: async (issueId) => {
+    const [res] = await connection.query(sql.selectIssueLabel, [issueId]);
+    const convertedResult = res.map((row) => ({ ...row }));
+    return convertedResult;
   },
 };
 

--- a/web-BE/models/issue_label.js
+++ b/web-BE/models/issue_label.js
@@ -1,0 +1,12 @@
+const connection = require('../config/db_connection');
+const sql = require('../config/query');
+
+const issueLabelModel = {
+  insert: async (issueId, labelArr) => {
+    const issueLabelData = labelArr.reduce((acc, curr) => [...acc, [issueId, curr]], []);
+    console.log('asdfsddfsef', issueLabelData);
+    await connection.query(sql.insertIssueLabel, [issueLabelData]);
+  },
+};
+
+module.exports = issueLabelModel;

--- a/web-BE/models/issue_label.js
+++ b/web-BE/models/issue_label.js
@@ -11,6 +11,9 @@ const issueLabelModel = {
     const convertedResult = res.map((row) => ({ ...row }));
     return convertedResult;
   },
+  delete: async (issueId, labelId) => {
+    await connection.query(sql.deleteIssueLabel, [issueId, labelId]);
+  },
 };
 
 module.exports = issueLabelModel;

--- a/web-BE/routes/api/index.js
+++ b/web-BE/routes/api/index.js
@@ -1,13 +1,13 @@
 const router = require('express').Router();
 const auth = require('./auth');
 // const comment = require("./comment");
-// const issue = require("./issue");
+const issue = require('./issue');
 const label = require('./label');
 const milestone = require('./milestone');
 
 router.use('/auth', auth);
 // router.use("/comment", comment);
-// router.use("/issue", issue);
+router.use('/issue', issue);
 router.use('/label', label);
 router.use('/milestone', milestone);
 

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -1,5 +1,6 @@
 const issueModel = require('../../../models/issue');
 const issueLabelModel = require('../../../models/issue_label');
+const assigneeModel = require('../../../models/assignee');
 
 const issueController = {
   create: async (req, res, next) => {
@@ -78,6 +79,24 @@ const issueController = {
     const { isopen: isOpen } = req.body;
     try {
       await issueModel.updateIsOpen(issueId, isOpen);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
+  },
+  addAssignee: async (req, res, next) => {
+    const { issueId, userId } = req.params;
+    try {
+      await assigneeModel.insert(issueId, userId);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
+  },
+  deleteAssignee: async (req, res, next) => {
+    const { issueId, userId } = req.params;
+    try {
+      await assigneeModel.delete(issueId, userId);
       res.sendStatus(200);
     } catch (error) {
       next(error);

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -102,6 +102,15 @@ const issueController = {
       next(error);
     }
   },
+  readAssignee: async (req, res, next) => {
+    const { issueId } = req.params;
+    try {
+      const assignee = await assigneeModel.select(issueId);
+      res.status(200).json(assignee);
+    } catch (error) {
+      next(error);
+    }
+  },
 };
 
 module.exports = issueController;

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -73,7 +73,16 @@ const issueController = {
       next(error);
     }
   },
-  
+  updateIsOpen: async (req, res, next) => {
+    const { issueId } = req.params;
+    const { isopen: isOpen } = req.body;
+    try {
+      await issueModel.updateIsOpen(issueId, isOpen);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
+  },
 };
 
 module.exports = issueController;

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -19,8 +19,13 @@ const issueController = {
       next(error);
     }
   },
-  read: async (req, res) => {
-
+  read: async (req, res, next) => {
+    try {
+      const issueArr = await issueModel.select();
+      res.status(200).json(issueArr);
+    } catch (error) {
+      next(error);
+    }
   },
   update: (req, res) => {
 

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -46,6 +46,15 @@ const issueController = {
       next(error);
     }
   },
+  deleteMilestone: async (req, res, next) => {
+    const { issueId } = req.params;
+    try {
+      await issueModel.deleteMilestone(issueId);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
+  },
   delete: (req, res) => {
 
   },

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -37,6 +37,15 @@ const issueController = {
       next(error);
     }
   },
+  addMilestone: async (req, res, next) => {
+    const { issueId, milestoneId } = req.params;
+    try {
+      await issueModel.insertMilestone(issueId, milestoneId);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
+  },
   delete: (req, res) => {
 
   },

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -1,0 +1,33 @@
+const { NotExtended } = require('http-errors');
+const issueModel = require('../../../models/issue');
+
+const issueController = {
+  create: async (req, res, next) => {
+    const {
+      writer,
+      title,
+      milestone,
+      write_time: writeTime,
+      label: labelArr,
+    } = req.body;
+    try {
+      const insertId = await issueModel.insert({
+        writer, title, milestone, writeTime, labelArr,
+      });
+      res.status(200).json({ insertId });
+    } catch (error) {
+      next(error);
+    }
+  },
+  read: async (req, res) => {
+
+  },
+  update: (req, res) => {
+
+  },
+  delete: (req, res) => {
+
+  },
+};
+
+module.exports = issueController;

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -1,5 +1,5 @@
-const { NotExtended } = require('http-errors');
 const issueModel = require('../../../models/issue');
+const issueLabelModel = require('../../../models/issue_label');
 
 const issueController = {
   create: async (req, res, next) => {
@@ -55,8 +55,14 @@ const issueController = {
       next(error);
     }
   },
-  delete: (req, res) => {
-
+  addLabel: async (req, res, next) => {
+    const { issueId, labelId } = req.params;
+    try {
+      await issueLabelModel.insert(issueId, [labelId]);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
   },
 };
 

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -64,6 +64,16 @@ const issueController = {
       next(error);
     }
   },
+  deleteLabel: async (req, res, next) => {
+    const { issueId, labelId } = req.params;
+    try {
+      await issueLabelModel.delete(issueId, labelId);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
+  },
+  
 };
 
 module.exports = issueController;

--- a/web-BE/routes/api/issue/controller.js
+++ b/web-BE/routes/api/issue/controller.js
@@ -27,8 +27,15 @@ const issueController = {
       next(error);
     }
   },
-  update: (req, res) => {
-
+  updateTitle: async (req, res, next) => {
+    const { issueId } = req.params;
+    const { title } = req.body;
+    try {
+      await issueModel.updateTitle(issueId, title);
+      res.sendStatus(200);
+    } catch (error) {
+      next(error);
+    }
   },
   delete: (req, res) => {
 

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -6,6 +6,7 @@ router.get('/', issueController.read);
 router.patch('/:issueId/title', issueController.updateTitle);
 router.post('/:issueId/milestone/:milestoneId', issueController.addMilestone);
 router.delete('/:issueId/milestone/', issueController.deleteMilestone);
+router.post('/:issueId/label/:labelId', issueController.addLabel);
 // router.delete('/:labelid', issueController.delete);
 
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const issueController = require('./controller');
+
+router.post('/', issueController.create);
+// router.get('/', issueController.read);
+// router.put('/:labelid', issueController.update);
+// router.delete('/:labelid', issueController.delete);
+
+module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -11,4 +11,5 @@ router.delete('/:issueId/label/:labelId', issueController.deleteLabel);
 router.patch('/:issueId/isopen', issueController.updateIsOpen);
 router.post('/:issueId/assignee/:userId', issueController.addAssignee);
 router.delete('/:issueId/assignee/:userId', issueController.deleteAssignee);
+router.get('/:issueId/assignee', issueController.readAssignee);
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 const issueController = require('./controller');
 
 router.post('/', issueController.create);
-// router.get('/', issueController.read);
+router.get('/', issueController.read);
 // router.put('/:labelid', issueController.update);
 // router.delete('/:labelid', issueController.delete);
 

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -4,6 +4,7 @@ const issueController = require('./controller');
 router.post('/', issueController.create);
 router.get('/', issueController.read);
 router.patch('/:issueId/title', issueController.updateTitle);
+router.post('/:issueId/milestone/:milestoneId', issueController.addMilestone);
 // router.delete('/:labelid', issueController.delete);
 
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -8,6 +8,7 @@ router.post('/:issueId/milestone/:milestoneId', issueController.addMilestone);
 router.delete('/:issueId/milestone/', issueController.deleteMilestone);
 router.post('/:issueId/label/:labelId', issueController.addLabel);
 router.delete('/:issueId/label/:labelId', issueController.deleteLabel);
+router.patch('/:issueId/isopen', issueController.updateIsOpen);
 // router.delete('/:labelid', issueController.delete);
 
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -3,7 +3,7 @@ const issueController = require('./controller');
 
 router.post('/', issueController.create);
 router.get('/', issueController.read);
-// router.put('/:labelid', issueController.update);
+router.patch('/:issueId/title', issueController.updateTitle);
 // router.delete('/:labelid', issueController.delete);
 
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -7,6 +7,7 @@ router.patch('/:issueId/title', issueController.updateTitle);
 router.post('/:issueId/milestone/:milestoneId', issueController.addMilestone);
 router.delete('/:issueId/milestone/', issueController.deleteMilestone);
 router.post('/:issueId/label/:labelId', issueController.addLabel);
+router.delete('/:issueId/label/:labelId', issueController.deleteLabel);
 // router.delete('/:labelid', issueController.delete);
 
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -9,6 +9,6 @@ router.delete('/:issueId/milestone/', issueController.deleteMilestone);
 router.post('/:issueId/label/:labelId', issueController.addLabel);
 router.delete('/:issueId/label/:labelId', issueController.deleteLabel);
 router.patch('/:issueId/isopen', issueController.updateIsOpen);
-// router.delete('/:labelid', issueController.delete);
-
+router.post('/:issueId/assignee/:userId', issueController.addAssignee);
+router.delete('/:issueId/assignee/:userId', issueController.deleteAssignee);
 module.exports = router;

--- a/web-BE/routes/api/issue/index.js
+++ b/web-BE/routes/api/issue/index.js
@@ -5,6 +5,7 @@ router.post('/', issueController.create);
 router.get('/', issueController.read);
 router.patch('/:issueId/title', issueController.updateTitle);
 router.post('/:issueId/milestone/:milestoneId', issueController.addMilestone);
+router.delete('/:issueId/milestone/', issueController.deleteMilestone);
 // router.delete('/:labelid', issueController.delete);
 
 module.exports = router;


### PR DESCRIPTION
# web-BE issue 관련 api 구현
## 관련 이슈 및 위키
**관련 이슈** : #23 #24 #25 #26 #27 #28 #29 #30 
## 내용
### issue api 구현
- create issue
- read all issue
- update issue title
- add issue milestone
- delete issue milestone
- add issue label
- delete issue label
- update isopen
- add issue assignee
- delete issue assignee
- read all assignee

### 주의할 부분?
> 9346ac2

issue table에 추가하고 나서 issue_label table에도 추가를 해야하는데 둘 중 하나만 값이 넣어지는 것을 방지하기 위해서 transaction을 사용했습니다.

> 9749b92

issue를 먼저  milestone, user과 join 해서 가져온 후에 각 issue에 해당하는 label들을 가져와서 합친 후 반환합니다.

> 8693edc

labelArr의 label의 개수에 따라서 중첩 array를 만들어서 bulk insert를 하도록 했습니다.

## Why?
> 9749b92

writer, assignee까지 join 해서 값을 가지고 오지 않은 이유는 User를 join 할 때 writer와 assignee를 구분할 수 있는 방법을 모르기 때문에 따로 api를 만들었습니다.