### PR TITLE
[feat] Github oAuth -> insert User route

### DIFF
--- a/web-BE/config/query.js
+++ b/web-BE/config/query.js
@@ -14,6 +14,7 @@ module.exports = {
     'UPDATE Milestone SET title=?, due_date=?, content=? WHERE milestone_id=?;',
   deleteMilestone: 'DELETE FROM Milestone WHERE milestone_id=?;',
   // user
+  insertUser: 'INSERT INTO User (username,social) VALUES (?,?)',
   selectUser: 'SELECT user_id, username, social FROM User WHERE username=? and social=?',
   // issue
   insertIssue:

--- a/web-BE/models/auth.js
+++ b/web-BE/models/auth.js
@@ -2,7 +2,12 @@ const connection = require('../config/db_connection');
 const sql = require('../config/query');
 
 const authModel = {
-  insert: () => true,
+  insert: async (username, social) => {
+    try {
+      const res = await connection.query(sql.insertUser, [username, social]);
+      return res[0].insertId;
+    } catch (err) { console.error(err); }
+  },
   select: async (username, social) => {
     try {
       const [res] = await connection.query(sql.selectUser, [username, social]);

--- a/web-BE/routes/api/auth/controller.js
+++ b/web-BE/routes/api/auth/controller.js
@@ -1,11 +1,15 @@
 const authModel = require('../../../models/auth');
 const axios = require('axios');
+
 const authController = {
-  checkUser: async (req, res) => {
-    const { social, username } = req.params;
+  checkUser: async ({username, social, url}) => {
+  // checkUser: async (req, res) => {
+  //   const { social, username } = req.params;
     const user = await authModel.select(username, social);
-    if (!user) return res.sendStatus(401);
-    return res.sendStatus(200);
+    if (!user) return false
+    return true
+    // if (!user) return res.sendStatus(401);
+    // return res.sendStatus(200);
   },
 
   getUserInfo: async (req, res) => {
@@ -14,22 +18,22 @@ const authController = {
     const getUserDataUrl = 'https://api.github.com/user';
     const reg = /access_token=(.*)&scope/;
 
-    try {
-        const result = await axios.post(getTokenUrl, null, {
-            params: {
-                client_id,
-                client_secret,
-                code
-            }
-        })
+    try { 
+      const result = await axios.post(getTokenUrl, null, {
+        params: { client_id, client_secret, code }
+      })
 
-        const token = reg.exec(result.data)[1]
-        const { data } = await axios({
-            method: 'get',
-            url: getUserDataUrl,
-            headers: { Authorization: `token ${token}` }
-        })
-        res.json({ userInfo : data });
+      const token = reg.exec(result.data)[1]
+      const { data : userData } = await axios({
+        method: 'get',
+        url: getUserDataUrl,
+        headers: { Authorization: `token ${token}` }
+      })
+
+      const { login:username, url } = userData
+      const userInfo = { username, social:'github' ,url }
+      const isExistUser = await authController.checkUser(userInfo)
+      res.json({ userInfo, isExistUser });
     } 
     catch (error) { console.error(error); }
  }

--- a/web-BE/routes/api/auth/controller.js
+++ b/web-BE/routes/api/auth/controller.js
@@ -2,6 +2,12 @@ const authModel = require('../../../models/auth');
 const axios = require('axios');
 
 const authController = {
+  addUser: async (req,res)=>{
+    const { username, social } = req.body
+    const insertUserId = await authModel.insert(username,social)
+    res.status(200).json({ insertUserId });
+  },
+
   checkUser: async ({username, social, url}) => {
   // checkUser: async (req, res) => {
   //   const { social, username } = req.params;

--- a/web-BE/routes/api/auth/index.js
+++ b/web-BE/routes/api/auth/index.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const authController = require('./controller');
 
 router.get('/oauth', authController.getUserInfo);
-router.get('/:social/:username', authController.checkUser);
+router.post('/', authController.addUser)
+// router.get('/:social/:username', authController.checkUser);
 
 module.exports = router;

--- a/web-FE/src/api/auth.js
+++ b/web-FE/src/api/auth.js
@@ -1,0 +1,25 @@
+import axios from "axios";
+const clientId = process.env.CLIENT_ID
+const clientSecret = process.env.CLIENT_SECRET
+
+export const saveUser = async ({username, social})=>{
+  const apiurl = "http://localhost:8080/api/auth"
+  const { insertUserId } = await axios.post( apiurl, { username, social } )
+}
+
+export const getUserInfo = async (code) => {
+  const apiurl = "http://localhost:8080/api/auth/oauth"
+  try{
+    const result = await axios.get(
+      `${apiurl}?code=${code}&client_id=${clientId}&client_secret=${clientSecret}`
+      );
+    const {userInfo, isExistUser} = result.data
+    return {userInfo, isExistUser}
+  } catch(error){
+    console.error(error)
+  }
+};
+
+export const linkTo = async () => {
+  window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}`;
+};

--- a/web-FE/src/api/auth.js
+++ b/web-FE/src/api/auth.js
@@ -20,6 +20,6 @@ export const getUserInfo = async (code) => {
   }
 };
 
-export const linkTo = async () => {
+export const linkToGetCode = async () => {
   window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}`;
 };

--- a/web-FE/src/components/githubLogin.jsx
+++ b/web-FE/src/components/githubLogin.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from "react";
+import { linkToGetCode, getUserInfo, saveUser } from '../api/auth';
+
+const GithubLogin = () => {
+  useEffect( async () => {
+    const reg = /.code=(.*)/
+    if(reg.test(window.location)){
+      const code = reg.exec(window.location)[1]
+      const {userInfo, isExistUser} = await getUserInfo(code)
+      if(isExistUser){
+        alert('login되었습니다')
+      }
+      else{
+        await saveUser(userInfo)
+        alert('회원가입되었습니다')
+      }
+    }
+    
+  });
+
+  return <button onClick={linkToGetCode}>GITHUB</button>;
+};
+
+
+export default GithubLogin;

--- a/web-FE/src/pages/Home.jsx
+++ b/web-FE/src/pages/Home.jsx
@@ -11,8 +11,8 @@ const App = () => {
       const result = await axios.get(
         `${apiurl}?code=${code}&client_id=${clientId}&client_secret=${clientSecret}`
         );
-      const {userInfo} = result.data
-      console.log(userInfo)
+      const {userInfo, isExistUser} = result.data
+      console.log(userInfo, isExistUser)
     } catch(error){
       console.error(error)
     }

--- a/web-FE/src/pages/Home.jsx
+++ b/web-FE/src/pages/Home.jsx
@@ -5,6 +5,11 @@ const App = () => {
   const clientId = process.env.CLIENT_ID
   const clientSecret = process.env.CLIENT_SECRET
 
+  const saveUser = async ({username, social})=>{
+    const apiurl = "http://localhost:8080/api/auth"
+    const { insertUserId } = await axios.post( apiurl, { username, social } )
+  }
+
   const getUserInfo = async (code) => {
     const apiurl = "http://localhost:8080/api/auth/oauth"
     try{

--- a/web-FE/src/pages/Home.jsx
+++ b/web-FE/src/pages/Home.jsx
@@ -1,25 +1,12 @@
-import React, { useEffect } from "react";
-import { linkToGetCode, getUserInfo, saveUser } from '../api/auth';
+import React from "react";
+import GithubLogin from "../components/githubLogin"
 
 const App = () => {
-  useEffect( async () => {
-    const reg = /.code=(.*)/
-    if(reg.test(window.location)){
-      const code = reg.exec(window.location)[1]
-      const {userInfo, isExistUser} = await getUserInfo(code)
-      if(isExistUser){
-        alert('login되었습니다')
-      }
-      else{
-        await saveUser(userInfo)
-        alert('회원가입되었습니다')
-      }
-    }
-    
-  });
-
-  return <button onClick={linkToGetCode}>GITHUB</button>;
+  return (
+    <div>
+      <GithubLogin />
+    </div>
+  )
 };
-
 
 export default App;

--- a/web-FE/src/pages/Home.jsx
+++ b/web-FE/src/pages/Home.jsx
@@ -12,24 +12,29 @@ const App = () => {
         `${apiurl}?code=${code}&client_id=${clientId}&client_secret=${clientSecret}`
         );
       const {userInfo, isExistUser} = result.data
-      console.log(userInfo, isExistUser)
+      return {userInfo, isExistUser}
     } catch(error){
       console.error(error)
     }
   };
 
   const linkTo = async () => {
-    window.location.href =
-      `https://github.com/login/oauth/authorize?client_id=${clientId}`;
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}`;
   };
 
-  useEffect(() => {
+  useEffect( async () => {
     const reg = /.code=(.*)/
     if(reg.test(window.location)){
       const code = reg.exec(window.location)[1]
-      localStorage.setItem("test", code);
-      getUserInfo(code)
+      const {userInfo, isExistUser} = await getUserInfo(code)
+      if(isExistUser){
+        alert('login되었습니다')
+      }else{
+        await saveUser(userInfo)
+        alert('회원가입되었습니다')
+      }
     }
+    
   });
 
   return <button onClick={linkTo}>GITHUB</button>;

--- a/web-FE/src/pages/Home.jsx
+++ b/web-FE/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { linkTo, getUserInfo, saveUser } from '../api/auth';
+import { linkToGetCode, getUserInfo, saveUser } from '../api/auth';
 
 const App = () => {
   useEffect( async () => {
@@ -18,7 +18,7 @@ const App = () => {
     
   });
 
-  return <button onClick={linkTo}>GITHUB</button>;
+  return <button onClick={linkToGetCode}>GITHUB</button>;
 };
 
 

--- a/web-FE/src/pages/Home.jsx
+++ b/web-FE/src/pages/Home.jsx
@@ -1,32 +1,7 @@
 import React, { useEffect } from "react";
-import axios from "axios";
+import { linkTo, getUserInfo, saveUser } from '../api/auth';
 
 const App = () => {
-  const clientId = process.env.CLIENT_ID
-  const clientSecret = process.env.CLIENT_SECRET
-
-  const saveUser = async ({username, social})=>{
-    const apiurl = "http://localhost:8080/api/auth"
-    const { insertUserId } = await axios.post( apiurl, { username, social } )
-  }
-
-  const getUserInfo = async (code) => {
-    const apiurl = "http://localhost:8080/api/auth/oauth"
-    try{
-      const result = await axios.get(
-        `${apiurl}?code=${code}&client_id=${clientId}&client_secret=${clientSecret}`
-        );
-      const {userInfo, isExistUser} = result.data
-      return {userInfo, isExistUser}
-    } catch(error){
-      console.error(error)
-    }
-  };
-
-  const linkTo = async () => {
-    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}`;
-  };
-
   useEffect( async () => {
     const reg = /.code=(.*)/
     if(reg.test(window.location)){
@@ -34,7 +9,8 @@ const App = () => {
       const {userInfo, isExistUser} = await getUserInfo(code)
       if(isExistUser){
         alert('login되었습니다')
-      }else{
+      }
+      else{
         await saveUser(userInfo)
         alert('회원가입되었습니다')
       }


### PR DESCRIPTION
# Github oAuth, Insert User route
## 관련 이슈 및 위키
#66 SNS 로그인 
## 내용

### [ On BE ] 

#### [feat] Set oAuth BE logic 
> 25b431c
-  `getUserInfo` 에서 받은 user info로 `checkUser` 를 실행하여 기존 회원인지 아닌지 Boolean 값을 얻는다.
  - `checkUser` 수정 : api requst 를 받지 않고 BE내부에서 호출 되므로 우선 주석처리 했습니다.
  - **클라이언트에서 api로 호출되는 부분이 없는 것으로 재윤님이 피드백 주셨으니 삭제 할게요!**
- Api를 호출한 Client에 user info와 기존회원 여부를 리스폰스로 넘겨준다.
  - `userInfo = {username: "JungSWon", social: "github", url: "https://api.github.com/users/JungSWon"}`
  - `isExistUser = true/false`

#### [feat] Add query , model, controller, router
> 0d3b56c 95afabe be4767f 1b3c4fe
- query : 유저 추가 쿼리 작성
- model : 유저 추가 모델 작성
  - **추후 클라이언트에서 필요할 가능성 염두하여 insertId 리턴**
- controller : authController 에 유저 추가 모듈 작성
  - 추가된 유저아이디인 `insertUserId` 리스폰스로 전달
- router : POST api/auth
  - checkUser부는 서버 내에서 호출 되는 모듈로, 라우터에서는 빼도 될 것으로 생각되어 우선 주석처리
  - **25b431c 와 마찬가지로 추후 삭제하겠습니다 ~**

### [ On FE ]

#### [feat] `getUserInfo` 리스폰스로 받은 기존 회원 여부에 따라 alert|함수호출 
> 04fe670
- isExistUser 의 경우 alert("로그인되었습니다")
- !isExistUser의 경우 saveUser 호출 및 alert("회원가입되었습니다")
  - **추후 회원가입 동의 확인을 거쳐 유저 추가 예정**

#### [feat] Save user on client : request api 
> 8eba6f0
- 서버에 POST api/auth 유저 회원가입을 요청하고 추가된 userId 받기

#### [refactor] Create `src/api/auth` 
> 5c6a970
- auth api 관련 모듈 리팩토링

#### [style] 명시적인 모듈명으로 수정 
> 2e1ea0e
- linkTo -> linkToGetCode

#### [refactor] Add src/components/githubLogin 
> 27f19cf
- 깃헙 로그인 컴포넌트를 만들어 분리하였다.

## Why?
- 리팩토링은 [React Docs - grouping by file type](https://reactjs.org/docs/faq-structure.html#grouping-by-file-type)을 참고했습니다 
- `checkUser`를 포함한 기존 User DB 를 read하는 api 부분은 주석처리하고 서버 내부 호출 모듈로 변경했습니다 
  - 클라이언트에서 해당 api 호출할 일이 없다는 피드백을 받아 추후 삭제 예정입니다! 