### PR TITLE
[fix] Network manager token 추가

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Network/NetworkManager.swift
+++ b/iOS/IssueTracker/IssueTracker/Network/NetworkManager.swift
@@ -9,13 +9,19 @@ import Foundation
 import Alamofire
 
 class NetworkManager {
+    
     public static let shared = NetworkManager()
-    func getRequest<T: Decodable>(url: URLs, type: T.Type, completion: @escaping (T?) -> Void) {
-        
-        let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImdpdGh1YnRlc3QiLCJzb2NpYWwiOiJnaXRodWIiLCJpYXQiOjE2MDQ1NDAwMjN9.6-w6o538wNQ6OLxiB5lqtO-gaSwpQBdgBRdS-YkFgG4"
-        let headers: HTTPHeaders = [
+    
+    let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImdpdGh1YnRlc3QiLCJzb2NpYWwiOiJnaXRodWIiLCJpYXQiOjE2MDQ1NDAwMjN9.6-w6o538wNQ6OLxiB5lqtO-gaSwpQBdgBRdS-YkFgG4"
+    let headers: HTTPHeaders
+    
+    private init() {
+        headers = [
             "Authorization": "Bearer \(token)"
         ]
+    }
+    
+    func getRequest<T: Decodable>(url: URLs, type: T.Type, completion: @escaping (T?) -> Void) {
         
         let alamo = AF.request(url.rawValue, method: .get, parameters: nil, headers: headers).validate(statusCode: 200..<300)
         
@@ -33,7 +39,7 @@ class NetworkManager {
     
     func postRequest<T: Encodable>(url: URLs, object: T, type: T.Type, completion: @escaping (NSDictionary) -> Void) {
         
-        let alamo = AF.request(url.rawValue, method: .post, parameters: object, encoder: JSONParameterEncoder.default).validate(statusCode: 200..<300)
+        let alamo = AF.request(url.rawValue, method: .post, parameters: object, encoder: JSONParameterEncoder.default, headers: headers).validate(statusCode: 200..<300)
         
         alamo.responseJSON { response in
             switch response.result {
@@ -48,7 +54,7 @@ class NetworkManager {
     }
     
     func deleteRequest(url: URLs, deleteID: Int, completion: @escaping (NSDictionary) -> Void) {
-        let alamo = AF.request("\(url.rawValue)/\(deleteID)", method: .delete, parameters: nil).validate(statusCode: 200..<300)
+        let alamo = AF.request("\(url.rawValue)/\(deleteID)", method: .delete, parameters: nil, headers: headers).validate(statusCode: 200..<300)
         
         alamo.responseJSON { response in
             switch response.result {
@@ -63,7 +69,7 @@ class NetworkManager {
     }
     
     func putRequest<T: Encodable>(url: URLs, updateID: Int, object: T, type: T.Type, completion: @escaping (NSDictionary) -> Void) {
-        let alamo = AF.request("\(url.rawValue)/\(updateID)", method: .put, parameters: object, encoder: JSONParameterEncoder.default).validate(statusCode: 200..<300)
+        let alamo = AF.request("\(url.rawValue)/\(updateID)", method: .put, parameters: object, encoder: JSONParameterEncoder.default, headers: headers).validate(statusCode: 200..<300)
         
         alamo.responseJSON { response in
             switch response.result {


### PR DESCRIPTION
# 제목
Network manager token 추가

## 관련 이슈 및 위키

## 내용
- 통신 시, token 을 넣기 위해 공통적으로 token 을 사용하도록 수정
- get 이외 함수에도 header 추가

## Why?
- 네트워크 기능 구현 시, token 필요
