### PR TITLE
[style] 레이블 및 마일스톤 화면 수정

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -1321,6 +1321,9 @@
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IUh-Op-b4p">
                                         <rect key="frame" x="25" y="92" width="30" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="30" id="9zi-we-aLJ"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -1344,6 +1347,9 @@
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k9l-4u-0H2">
                                         <rect key="frame" x="25" y="152" width="30" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="30" id="ODy-3F-wHr"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -1533,28 +1539,28 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qvc-F7-sJg" userLabel="AddButtonView">
-                                <rect key="frame" x="0.0" y="44" width="414" height="60"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="100"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DYc-Kx-v3w">
-                                        <rect key="frame" x="370.5" y="5" width="23.5" height="22"/>
+                                        <rect key="frame" x="372.5" y="10" width="21.5" height="22"/>
                                         <state key="normal">
-                                            <imageReference key="image" image="plus.app.fill" catalog="system" symbolScale="large"/>
+                                            <imageReference key="image" image="plus" catalog="system" symbolScale="large"/>
                                         </state>
                                         <connections>
                                             <action selector="addButtonDidTouch:" destination="NoH-DS-0tR" eventType="touchUpInside" id="VL9-AB-3aL"/>
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="마일스톤" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i44-ac-znE">
-                                        <rect key="frame" x="20" y="20" width="86.5" height="30"/>
-                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
+                                        <rect key="frame" x="20" y="53" width="104" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="30"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mbu-qu-qXr">
-                                        <rect key="frame" x="0.0" y="55" width="414" height="2"/>
+                                        <rect key="frame" x="0.0" y="99" width="414" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray4Color"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="q0a-fW-NXR"/>
+                                            <constraint firstAttribute="height" constant="1" id="HsO-zc-ntg"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -1565,44 +1571,44 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="mbu-qu-qXr" firstAttribute="top" secondItem="i44-ac-znE" secondAttribute="bottom" constant="5" id="2b9-Dw-vfX"/>
-                                    <constraint firstItem="mbu-qu-qXr" firstAttribute="leading" secondItem="qvc-F7-sJg" secondAttribute="leading" id="61Q-cg-pQe"/>
-                                    <constraint firstAttribute="trailing" secondItem="DYc-Kx-v3w" secondAttribute="trailing" constant="20" id="ILF-uu-Yz8"/>
-                                    <constraint firstItem="DYc-Kx-v3w" firstAttribute="top" secondItem="qvc-F7-sJg" secondAttribute="top" constant="5" id="NNF-iM-ZVT"/>
-                                    <constraint firstItem="i44-ac-znE" firstAttribute="top" secondItem="qvc-F7-sJg" secondAttribute="top" constant="20" id="Pnr-Ko-pER"/>
-                                    <constraint firstAttribute="height" constant="60" id="Q1N-ID-BUx"/>
-                                    <constraint firstAttribute="trailing" secondItem="mbu-qu-qXr" secondAttribute="trailing" id="Wvq-ZH-MG5"/>
-                                    <constraint firstItem="i44-ac-znE" firstAttribute="leading" secondItem="qvc-F7-sJg" secondAttribute="leading" constant="20" id="gfW-hh-wjn"/>
+                                    <constraint firstAttribute="bottom" secondItem="mbu-qu-qXr" secondAttribute="bottom" id="59j-bh-uVT"/>
+                                    <constraint firstItem="i44-ac-znE" firstAttribute="leading" secondItem="qvc-F7-sJg" secondAttribute="leading" constant="20" id="FUe-Sv-9Fw"/>
+                                    <constraint firstItem="mbu-qu-qXr" firstAttribute="top" secondItem="i44-ac-znE" secondAttribute="bottom" constant="10" id="Gko-35-b0t"/>
+                                    <constraint firstItem="mbu-qu-qXr" firstAttribute="leading" secondItem="qvc-F7-sJg" secondAttribute="leading" id="Oqg-lb-kAq"/>
+                                    <constraint firstAttribute="height" constant="100" id="Q1N-ID-BUx"/>
+                                    <constraint firstAttribute="trailing" secondItem="DYc-Kx-v3w" secondAttribute="trailing" constant="20" id="Xsh-WJ-nVi"/>
+                                    <constraint firstItem="DYc-Kx-v3w" firstAttribute="top" secondItem="qvc-F7-sJg" secondAttribute="top" constant="10" id="eGz-G9-ohX"/>
+                                    <constraint firstAttribute="trailing" secondItem="mbu-qu-qXr" secondAttribute="trailing" id="kyN-hf-j2F"/>
                                 </constraints>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="NRp-TB-chB">
-                                <rect key="frame" x="0.0" y="104" width="414" height="709"/>
+                                <rect key="frame" x="0.0" y="144" width="414" height="669"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="dKa-QL-V3S">
-                                    <size key="itemSize" width="414" height="100"/>
+                                    <size key="itemSize" width="414" height="84"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="MilestoneCollectionViewCell" reuseIdentifier="MilestoneCollectionViewCell" id="OMy-qx-1In" customClass="MilestoneCollectionViewCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="95"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="84"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="P3l-VI-nRk">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="95"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="84"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="마일스톤" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="86J-Hv-DQh" customClass="PaddedLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="20" y="10" width="48.5" height="17"/>
+                                                    <rect key="frame" x="20" y="15" width="48.5" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="paddingWidth">
-                                                            <real key="value" value="10"/>
+                                                            <real key="value" value="14"/>
                                                         </userDefinedRuntimeAttribute>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="paddingHeight">
-                                                            <real key="value" value="5"/>
+                                                            <real key="value" value="8"/>
                                                         </userDefinedRuntimeAttribute>
                                                         <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
                                                             <color key="value" systemColor="systemGrayColor"/>
@@ -1611,59 +1617,62 @@
                                                             <real key="value" value="1"/>
                                                         </userDefinedRuntimeAttribute>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                            <real key="value" value="5"/>
+                                                            <real key="value" value="8"/>
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 10월 28일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PKP-uQ-X3Q">
-                                                    <rect key="frame" x="88.5" y="12.5" width="135" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <rect key="frame" x="83.5" y="15.5" width="125.5" height="16"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="95%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NIR-NK-Qfu">
-                                                    <rect key="frame" x="358" y="10" width="36" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <rect key="frame" x="360" y="15" width="34" height="18"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                                     <color key="textColor" red="0.24694415929999999" green="0.42559111119999998" blue="0.223492682" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="마일스톤 설명!!!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hsb-dU-Q9w">
-                                                    <rect key="frame" x="20" y="42" width="108" height="21"/>
+                                                    <rect key="frame" x="20" y="47" width="107.5" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LpD-bR-O4X">
-                                                    <rect key="frame" x="351" y="42" width="43" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <rect key="frame" x="354" y="43" width="40" height="16"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="19 closed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBJ-5n-O2T">
-                                                    <rect key="frame" x="332" y="63" width="62" height="17"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="19 closed" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HBJ-5n-O2T">
+                                                    <rect key="frame" x="324" y="62" width="70" height="16"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="70" id="9cJ-Uk-EN3"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="NIR-NK-Qfu" firstAttribute="top" secondItem="P3l-VI-nRk" secondAttribute="top" constant="10" id="2Ib-OO-Aac"/>
-                                                <constraint firstItem="HBJ-5n-O2T" firstAttribute="top" secondItem="LpD-bR-O4X" secondAttribute="bottom" constant="4" id="AYB-KL-eHB"/>
-                                                <constraint firstItem="PKP-uQ-X3Q" firstAttribute="top" secondItem="P3l-VI-nRk" secondAttribute="top" constant="12.5" id="MV7-L8-hrj"/>
+                                                <constraint firstItem="PKP-uQ-X3Q" firstAttribute="centerY" secondItem="86J-Hv-DQh" secondAttribute="centerY" id="DDp-Zc-bUg"/>
+                                                <constraint firstItem="hsb-dU-Q9w" firstAttribute="leading" secondItem="86J-Hv-DQh" secondAttribute="leading" id="M5C-fJ-rcP"/>
+                                                <constraint firstItem="NIR-NK-Qfu" firstAttribute="top" secondItem="86J-Hv-DQh" secondAttribute="top" id="MFW-cp-Ioh"/>
                                                 <constraint firstAttribute="trailing" secondItem="NIR-NK-Qfu" secondAttribute="trailing" constant="20" id="Ogy-Op-9hZ"/>
-                                                <constraint firstItem="LpD-bR-O4X" firstAttribute="top" secondItem="hsb-dU-Q9w" secondAttribute="top" id="PzZ-am-KqP"/>
-                                                <constraint firstAttribute="bottom" secondItem="HBJ-5n-O2T" secondAttribute="bottom" constant="15" id="SYE-XR-M5G"/>
+                                                <constraint firstItem="NIR-NK-Qfu" firstAttribute="trailing" secondItem="LpD-bR-O4X" secondAttribute="trailing" id="QWt-sB-MBU"/>
                                                 <constraint firstItem="hsb-dU-Q9w" firstAttribute="top" secondItem="86J-Hv-DQh" secondAttribute="bottom" constant="15" id="SsN-Vj-Nhb"/>
-                                                <constraint firstItem="hsb-dU-Q9w" firstAttribute="leading" secondItem="P3l-VI-nRk" secondAttribute="leading" constant="20" id="WWx-qb-Nc5"/>
-                                                <constraint firstAttribute="trailing" secondItem="LpD-bR-O4X" secondAttribute="trailing" constant="20" id="hGr-Bq-igs"/>
-                                                <constraint firstItem="LpD-bR-O4X" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hsb-dU-Q9w" secondAttribute="trailing" priority="750" constant="10" id="lAj-JC-UiO"/>
-                                                <constraint firstAttribute="trailing" secondItem="HBJ-5n-O2T" secondAttribute="trailing" constant="20" id="nck-mL-MuW"/>
+                                                <constraint firstItem="HBJ-5n-O2T" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hsb-dU-Q9w" secondAttribute="trailing" priority="750" constant="10" id="eo5-rg-F8n"/>
+                                                <constraint firstItem="HBJ-5n-O2T" firstAttribute="top" secondItem="LpD-bR-O4X" secondAttribute="bottom" constant="3" id="nzk-Wv-5c9"/>
                                                 <constraint firstItem="86J-Hv-DQh" firstAttribute="leading" secondItem="P3l-VI-nRk" secondAttribute="leading" constant="20" id="puX-6m-fr5"/>
-                                                <constraint firstItem="PKP-uQ-X3Q" firstAttribute="leading" secondItem="86J-Hv-DQh" secondAttribute="trailing" constant="20" id="rll-13-HB9"/>
-                                                <constraint firstItem="86J-Hv-DQh" firstAttribute="top" secondItem="P3l-VI-nRk" secondAttribute="top" constant="10" id="xhI-vs-1Wk"/>
+                                                <constraint firstItem="PKP-uQ-X3Q" firstAttribute="leading" secondItem="86J-Hv-DQh" secondAttribute="trailing" constant="15" id="rll-13-HB9"/>
+                                                <constraint firstItem="NIR-NK-Qfu" firstAttribute="trailing" secondItem="HBJ-5n-O2T" secondAttribute="trailing" id="sIP-pj-b4O"/>
+                                                <constraint firstAttribute="bottom" secondItem="hsb-dU-Q9w" secondAttribute="bottom" constant="16" id="uJQ-rE-Hwo"/>
+                                                <constraint firstItem="LpD-bR-O4X" firstAttribute="top" secondItem="NIR-NK-Qfu" secondAttribute="bottom" constant="10" id="wSS-Da-rUk"/>
+                                                <constraint firstItem="86J-Hv-DQh" firstAttribute="top" secondItem="P3l-VI-nRk" secondAttribute="top" constant="15" id="xhI-vs-1Wk"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="414" height="95"/>
+                                        <size key="customSize" width="414" height="84"/>
                                         <connections>
                                             <outlet property="closedLabel" destination="HBJ-5n-O2T" id="baF-qT-Rrn"/>
                                             <outlet property="contentLabel" destination="hsb-dU-Q9w" id="8ug-bX-mNv"/>
@@ -1744,68 +1753,65 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Abo-Nd-oSK">
-                                        <rect key="frame" x="25" y="77" width="30" height="21"/>
+                                        <rect key="frame" x="25" y="92" width="30" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="30" id="1cl-jI-T04"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rtb-YI-n1M">
-                                        <rect key="frame" x="70" y="71" width="236" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rtb-YI-n1M">
+                                        <rect key="frame" x="70" y="92" width="236" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l18-8g-mv7">
-                                        <rect key="frame" x="20" y="113" width="291" height="2"/>
+                                        <rect key="frame" x="20" y="121" width="291" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="bcf-tD-GyM"/>
+                                            <constraint firstAttribute="height" constant="1" id="bcf-tD-GyM"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="noO-ti-kwo">
-                                        <rect key="frame" x="20" y="176" width="291" height="2"/>
+                                        <rect key="frame" x="20" y="191" width="291" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="fxk-9k-wqN"/>
+                                            <constraint firstAttribute="height" constant="1" id="Ddv-Qi-wQt"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완료 날짜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NIb-pB-m1r">
-                                        <rect key="frame" x="25" y="125" width="29.5" height="41"/>
+                                        <rect key="frame" x="25" y="142" width="29.5" height="41"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="yyyy-mm-dd(선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-t6-uus">
-                                        <rect key="frame" x="69.5" y="132" width="236.5" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="yyyy-mm-dd(선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-t6-uus">
+                                        <rect key="frame" x="69.5" y="152.5" width="236.5" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0IS-7r-oHS">
-                                        <rect key="frame" x="25" y="193" width="30" height="21"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1LF-e8-YbL">
-                                        <rect key="frame" x="20" y="229" width="291" height="2"/>
+                                        <rect key="frame" x="20" y="250" width="291" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="WMC-IP-ke4"/>
+                                            <constraint firstAttribute="height" constant="1" id="QIS-aS-vxz"/>
                                         </constraints>
                                     </view>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7dZ-0C-N2l">
-                                        <rect key="frame" x="70" y="187" width="236" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7dZ-0C-N2l">
+                                        <rect key="frame" x="70" y="222.5" width="236" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Osc-z8-PC0">
-                                        <rect key="frame" x="25" y="272" width="39" height="30"/>
+                                        <rect key="frame" x="20" y="282" width="39" height="30"/>
                                         <state key="normal" title="초기화"/>
                                         <connections>
                                             <action selector="resetButtonDidTouch:" destination="aEI-1d-dzR" eventType="touchUpInside" id="wJX-vU-V4B"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1pi-67-7MR">
-                                        <rect key="frame" x="251" y="267" width="60" height="40"/>
+                                        <rect key="frame" x="251" y="272" width="60" height="40"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="BIF-y0-eCm"/>
@@ -1826,42 +1832,51 @@
                                             <action selector="saveButtonDidTouch:" destination="aEI-1d-dzR" eventType="touchUpInside" id="yHa-y2-3YJ"/>
                                         </connections>
                                     </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0IS-7r-oHS">
+                                        <rect key="frame" x="25" y="222" width="30" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="30" id="FKb-dt-83h"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="1LF-e8-YbL" firstAttribute="top" secondItem="0IS-7r-oHS" secondAttribute="bottom" constant="15" id="3yR-Xh-DT2"/>
-                                    <constraint firstItem="0IS-7r-oHS" firstAttribute="top" secondItem="noO-ti-kwo" secondAttribute="bottom" constant="15" id="5h7-U5-wPE"/>
                                     <constraint firstAttribute="trailing" secondItem="l18-8g-mv7" secondAttribute="trailing" constant="20" id="A3x-uu-fsY"/>
-                                    <constraint firstAttribute="trailing" secondItem="noO-ti-kwo" secondAttribute="trailing" constant="20" id="AZ3-Lf-bWa"/>
-                                    <constraint firstItem="Osc-z8-PC0" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="25" id="Aqx-KC-fAp"/>
+                                    <constraint firstItem="Osc-z8-PC0" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="20" id="Aqx-KC-fAp"/>
                                     <constraint firstAttribute="trailing" secondItem="h6u-If-mha" secondAttribute="trailing" id="BvG-W4-eAa"/>
                                     <constraint firstItem="ZDk-iH-86O" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="15" id="Bzm-hG-Aoo"/>
                                     <constraint firstAttribute="trailing" secondItem="1pi-67-7MR" secondAttribute="trailing" constant="20" id="CIp-XH-Bfs"/>
                                     <constraint firstItem="l18-8g-mv7" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="20" id="DiA-73-rML"/>
+                                    <constraint firstItem="noO-ti-kwo" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="20" id="DpH-FE-idp"/>
                                     <constraint firstItem="Abo-Nd-oSK" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="25" id="FFV-s7-5gY"/>
                                     <constraint firstItem="h6u-If-mha" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" id="H17-CY-uiE"/>
                                     <constraint firstAttribute="trailing" secondItem="rtb-YI-n1M" secondAttribute="trailing" constant="25" id="H9u-n9-KGX"/>
-                                    <constraint firstItem="1LF-e8-YbL" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="20" id="HwQ-j1-tyM"/>
-                                    <constraint firstItem="Abo-Nd-oSK" firstAttribute="top" secondItem="h6u-If-mha" secondAttribute="bottom" constant="15" id="INS-Yu-Sqz"/>
+                                    <constraint firstItem="Abo-Nd-oSK" firstAttribute="top" secondItem="h6u-If-mha" secondAttribute="bottom" constant="30" id="INS-Yu-Sqz"/>
                                     <constraint firstAttribute="trailing" secondItem="7dZ-0C-N2l" secondAttribute="trailing" constant="25" id="JHJ-tD-479"/>
-                                    <constraint firstItem="noO-ti-kwo" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="20" id="Nce-rh-DdX"/>
-                                    <constraint firstAttribute="bottom" secondItem="Osc-z8-PC0" secondAttribute="bottom" constant="25" id="SRt-Yi-CD1"/>
-                                    <constraint firstItem="7dZ-0C-N2l" firstAttribute="leading" secondItem="0IS-7r-oHS" secondAttribute="trailing" constant="15" id="Ucb-Tt-uCt"/>
-                                    <constraint firstItem="NIb-pB-m1r" firstAttribute="top" secondItem="l18-8g-mv7" secondAttribute="bottom" constant="10" id="VIs-Kq-8AX"/>
+                                    <constraint firstAttribute="bottom" secondItem="Osc-z8-PC0" secondAttribute="bottom" constant="15" id="SRt-Yi-CD1"/>
+                                    <constraint firstItem="NIb-pB-m1r" firstAttribute="top" secondItem="l18-8g-mv7" secondAttribute="bottom" constant="20" id="Uwf-gN-h0O"/>
+                                    <constraint firstItem="7dZ-0C-N2l" firstAttribute="centerY" secondItem="0IS-7r-oHS" secondAttribute="centerY" id="V7m-XP-pAI"/>
+                                    <constraint firstItem="1LF-e8-YbL" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="20" id="V9U-Iw-sgb"/>
                                     <constraint firstItem="h6u-If-mha" firstAttribute="top" secondItem="ZDk-iH-86O" secondAttribute="bottom" constant="15" id="X6K-5s-b8v"/>
+                                    <constraint firstItem="1LF-e8-YbL" firstAttribute="top" secondItem="7dZ-0C-N2l" secondAttribute="bottom" constant="8" id="a0I-y6-cVe"/>
                                     <constraint firstItem="Wrf-t6-uus" firstAttribute="leading" secondItem="NIb-pB-m1r" secondAttribute="trailing" constant="15" id="aNS-EW-d1M"/>
                                     <constraint firstAttribute="trailing" secondItem="Wrf-t6-uus" secondAttribute="trailing" constant="25" id="dQp-4f-CdE"/>
-                                    <constraint firstItem="1LF-e8-YbL" firstAttribute="top" secondItem="7dZ-0C-N2l" secondAttribute="bottom" constant="8" id="ehm-MM-SqU"/>
-                                    <constraint firstAttribute="trailing" secondItem="1LF-e8-YbL" secondAttribute="trailing" constant="20" id="gXi-zi-BIj"/>
-                                    <constraint firstItem="l18-8g-mv7" firstAttribute="top" secondItem="Abo-Nd-oSK" secondAttribute="bottom" constant="15" id="gyo-hz-GXH"/>
+                                    <constraint firstItem="noO-ti-kwo" firstAttribute="top" secondItem="NIb-pB-m1r" secondAttribute="bottom" constant="8" id="drI-hS-L7v"/>
+                                    <constraint firstItem="7dZ-0C-N2l" firstAttribute="leading" secondItem="0IS-7r-oHS" secondAttribute="trailing" priority="900" constant="15" id="e4q-Wc-tFY"/>
+                                    <constraint firstItem="0IS-7r-oHS" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="25" id="fbv-72-dPQ"/>
+                                    <constraint firstItem="0IS-7r-oHS" firstAttribute="top" secondItem="noO-ti-kwo" secondAttribute="bottom" constant="30" id="hVD-Xk-QTM"/>
                                     <constraint firstItem="NIb-pB-m1r" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="25" id="jjU-es-fV6"/>
                                     <constraint firstItem="ZDk-iH-86O" firstAttribute="top" secondItem="Ly3-pw-1kU" secondAttribute="top" constant="15" id="lK6-yI-evf"/>
-                                    <constraint firstAttribute="bottom" secondItem="1pi-67-7MR" secondAttribute="bottom" constant="20" id="m3b-sc-fa8"/>
-                                    <constraint firstItem="rtb-YI-n1M" firstAttribute="leading" secondItem="Abo-Nd-oSK" secondAttribute="trailing" constant="15" id="p8s-Fv-QnL"/>
-                                    <constraint firstItem="noO-ti-kwo" firstAttribute="top" secondItem="Wrf-t6-uus" secondAttribute="bottom" constant="10" id="pQ5-KJ-cfi"/>
-                                    <constraint firstItem="0IS-7r-oHS" firstAttribute="leading" secondItem="Ly3-pw-1kU" secondAttribute="leading" constant="25" id="vUt-iW-9WZ"/>
+                                    <constraint firstAttribute="bottom" secondItem="1pi-67-7MR" secondAttribute="bottom" constant="15" id="m3b-sc-fa8"/>
+                                    <constraint firstItem="rtb-YI-n1M" firstAttribute="leading" secondItem="Abo-Nd-oSK" secondAttribute="trailing" priority="900" constant="15" id="p8s-Fv-QnL"/>
+                                    <constraint firstAttribute="trailing" secondItem="noO-ti-kwo" secondAttribute="trailing" constant="20" id="sOB-oV-ACg"/>
+                                    <constraint firstItem="Wrf-t6-uus" firstAttribute="centerY" secondItem="NIb-pB-m1r" secondAttribute="centerY" id="vBb-dM-ald"/>
+                                    <constraint firstAttribute="trailing" secondItem="1LF-e8-YbL" secondAttribute="trailing" constant="20" id="vH9-29-5VJ"/>
                                     <constraint firstItem="l18-8g-mv7" firstAttribute="top" secondItem="rtb-YI-n1M" secondAttribute="bottom" constant="8" id="wQC-YO-6TT"/>
-                                    <constraint firstItem="noO-ti-kwo" firstAttribute="top" secondItem="NIb-pB-m1r" secondAttribute="bottom" constant="10" id="zMT-RM-BEQ"/>
+                                    <constraint firstItem="rtb-YI-n1M" firstAttribute="centerY" secondItem="Abo-Nd-oSK" secondAttribute="centerY" id="zRR-0i-qtX"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -1922,7 +1937,6 @@
         <image name="gobackward" catalog="system" width="121" height="128"/>
         <image name="newIssue" width="64" height="64"/>
         <image name="plus" catalog="system" width="128" height="113"/>
-        <image name="plus.app.fill" catalog="system" width="128" height="114"/>
         <image name="up" width="64" height="64"/>
         <namedColor name="openIssue Background Color">
             <color red="0.42699998617172241" green="0.87099999189376831" blue="0.49799999594688416" alpha="0.30300000309944153" colorSpace="custom" customColorSpace="displayP3"/>

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -1167,28 +1167,29 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CQQ-JO-N5c" userLabel="AddButtonView">
-                                <rect key="frame" x="0.0" y="44" width="414" height="60"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="100"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ahz-e6-15y">
-                                        <rect key="frame" x="370.5" y="5" width="23.5" height="22"/>
+                                        <rect key="frame" x="372.5" y="10" width="21.5" height="22"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <state key="normal">
-                                            <imageReference key="image" image="plus.app.fill" catalog="system" symbolScale="large"/>
+                                            <imageReference key="image" image="plus" catalog="system" symbolScale="large"/>
                                         </state>
                                         <connections>
                                             <action selector="addButtonDidTouch:" destination="zmw-gG-ecc" eventType="touchUpInside" id="Cye-jA-LWF"/>
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="daW-wL-kux">
-                                        <rect key="frame" x="20" y="20" width="65" height="30"/>
-                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="25"/>
+                                        <rect key="frame" x="20" y="53" width="78" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="30"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9b7-bK-kgc">
-                                        <rect key="frame" x="0.0" y="55" width="414" height="2"/>
+                                        <rect key="frame" x="0.0" y="99" width="414" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray4Color"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="YIw-Ev-SwC"/>
+                                            <constraint firstAttribute="height" constant="1" id="llf-Ug-t2q"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -1199,68 +1200,68 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="daW-wL-kux" firstAttribute="leading" secondItem="CQQ-JO-N5c" secondAttribute="leading" constant="20" id="QLk-D8-IBN"/>
-                                    <constraint firstItem="Ahz-e6-15y" firstAttribute="top" secondItem="CQQ-JO-N5c" secondAttribute="top" constant="5" id="Sa3-Kt-WoQ"/>
-                                    <constraint firstAttribute="trailing" secondItem="9b7-bK-kgc" secondAttribute="trailing" id="UYd-XZ-Lw5"/>
-                                    <constraint firstItem="daW-wL-kux" firstAttribute="top" secondItem="CQQ-JO-N5c" secondAttribute="top" constant="20" id="YYU-ge-UcI"/>
-                                    <constraint firstItem="9b7-bK-kgc" firstAttribute="leading" secondItem="CQQ-JO-N5c" secondAttribute="leading" id="gqL-r7-Pg5"/>
-                                    <constraint firstItem="9b7-bK-kgc" firstAttribute="top" secondItem="daW-wL-kux" secondAttribute="bottom" constant="5" id="hYc-bw-5Fa"/>
+                                    <constraint firstAttribute="trailing" secondItem="9b7-bK-kgc" secondAttribute="trailing" id="2CV-eH-JXo"/>
+                                    <constraint firstAttribute="bottom" secondItem="9b7-bK-kgc" secondAttribute="bottom" id="A0k-KO-YWy"/>
+                                    <constraint firstItem="daW-wL-kux" firstAttribute="leading" secondItem="CQQ-JO-N5c" secondAttribute="leading" constant="20" id="Doz-yn-88C"/>
+                                    <constraint firstItem="Ahz-e6-15y" firstAttribute="top" secondItem="CQQ-JO-N5c" secondAttribute="top" constant="10" id="Sa3-Kt-WoQ"/>
                                     <constraint firstAttribute="trailing" secondItem="Ahz-e6-15y" secondAttribute="trailing" constant="20" id="o64-v0-elh"/>
-                                    <constraint firstAttribute="height" constant="60" id="s8Z-LG-s8T"/>
+                                    <constraint firstItem="9b7-bK-kgc" firstAttribute="leading" secondItem="CQQ-JO-N5c" secondAttribute="leading" id="r6m-3d-tXB"/>
+                                    <constraint firstAttribute="height" constant="100" id="s8Z-LG-s8T"/>
+                                    <constraint firstItem="9b7-bK-kgc" firstAttribute="top" secondItem="daW-wL-kux" secondAttribute="bottom" constant="10" id="txr-R4-jYA"/>
                                 </constraints>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="BHZ-rg-SPs">
-                                <rect key="frame" x="0.0" y="104" width="414" height="709"/>
+                                <rect key="frame" x="0.0" y="144" width="414" height="669"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="9D2-Ec-2qq">
-                                    <size key="itemSize" width="414" height="115"/>
+                                    <size key="itemSize" width="414" height="69"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="LabelCollectionViewCell" reuseIdentifier="LabelCollectionViewCell" id="PPo-7N-Ssz" customClass="LabelCollectionViewCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="69"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="SmH-AO-Fll">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="69"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xlb-je-POt" customClass="PaddedLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="20" y="10" width="41.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="15" width="31" height="14.5"/>
                                                     <color key="backgroundColor" systemColor="systemYellowColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="12"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="paddingWidth">
-                                                            <real key="value" value="5"/>
+                                                            <real key="value" value="14"/>
                                                         </userDefinedRuntimeAttribute>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="paddingHeight">
-                                                            <real key="value" value="5"/>
+                                                            <real key="value" value="8"/>
                                                         </userDefinedRuntimeAttribute>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                            <real key="value" value="5"/>
+                                                            <real key="value" value="10"/>
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="descriptionLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cXp-xV-Ffy">
-                                                    <rect key="frame" x="20" y="43" width="374" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <rect key="frame" x="20" y="37.5" width="374" height="18"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="cXp-xV-Ffy" firstAttribute="leading" secondItem="SmH-AO-Fll" secondAttribute="leading" constant="20" id="TiS-oY-iFE"/>
-                                                <constraint firstAttribute="bottom" secondItem="cXp-xV-Ffy" secondAttribute="bottom" constant="26" id="dn2-8q-74I"/>
+                                                <constraint firstAttribute="bottom" secondItem="cXp-xV-Ffy" secondAttribute="bottom" constant="13.5" id="GqU-9a-lpN"/>
+                                                <constraint firstAttribute="trailing" secondItem="cXp-xV-Ffy" secondAttribute="trailing" constant="20" id="h4X-2z-8Os"/>
                                                 <constraint firstItem="Xlb-je-POt" firstAttribute="leading" secondItem="SmH-AO-Fll" secondAttribute="leading" constant="20" id="m0u-jr-t59"/>
-                                                <constraint firstItem="Xlb-je-POt" firstAttribute="top" secondItem="SmH-AO-Fll" secondAttribute="top" constant="10" id="mgw-ND-0GD"/>
-                                                <constraint firstItem="cXp-xV-Ffy" firstAttribute="top" secondItem="Xlb-je-POt" secondAttribute="bottom" constant="12.5" id="qnE-1K-oEH"/>
-                                                <constraint firstAttribute="trailing" secondItem="cXp-xV-Ffy" secondAttribute="trailing" constant="20" id="yVy-I8-672"/>
+                                                <constraint firstItem="cXp-xV-Ffy" firstAttribute="top" secondItem="Xlb-je-POt" secondAttribute="bottom" constant="8" id="mej-yx-idn"/>
+                                                <constraint firstItem="Xlb-je-POt" firstAttribute="top" secondItem="SmH-AO-Fll" secondAttribute="top" constant="15" id="mgw-ND-0GD"/>
+                                                <constraint firstItem="cXp-xV-Ffy" firstAttribute="leading" secondItem="SmH-AO-Fll" secondAttribute="leading" constant="20" id="wWM-y8-RUl"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="414" height="90"/>
+                                        <size key="customSize" width="414" height="69"/>
                                         <connections>
                                             <outlet property="descriptionLabel" destination="cXp-xV-Ffy" id="dfJ-Pu-uFQ"/>
                                             <outlet property="nameLabel" destination="Xlb-je-POt" id="6XJ-gI-Vf4"/>
@@ -1319,65 +1320,70 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IUh-Op-b4p">
-                                        <rect key="frame" x="25" y="77" width="30" height="21"/>
+                                        <rect key="frame" x="25" y="92" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DBb-Db-8Hr">
-                                        <rect key="frame" x="20" y="113" width="291" height="2"/>
+                                        <rect key="frame" x="20" y="121" width="291" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="2eA-sz-uxZ"/>
+                                            <constraint firstAttribute="height" constant="1" id="hrC-Xz-JG2"/>
                                         </constraints>
                                     </view>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hdK-Cl-gN9">
-                                        <rect key="frame" x="70" y="71" width="236" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hdK-Cl-gN9">
+                                        <rect key="frame" x="70" y="92" width="236" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k9l-4u-0H2">
-                                        <rect key="frame" x="25" y="130" width="30" height="21"/>
+                                        <rect key="frame" x="25" y="152" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R2S-uP-pJN">
-                                        <rect key="frame" x="20" y="166" width="291" height="2"/>
+                                        <rect key="frame" x="20" y="181" width="291" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="yhz-vP-3pb"/>
+                                            <constraint firstAttribute="height" constant="1" id="yhz-vP-3pb"/>
                                         </constraints>
                                     </view>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YzO-03-Taz">
-                                        <rect key="frame" x="70" y="124" width="236" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YzO-03-Taz">
+                                        <rect key="frame" x="70" y="152" width="236" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="색상" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dTZ-Iv-3o8">
-                                        <rect key="frame" x="25" y="188" width="30" height="21"/>
+                                        <rect key="frame" x="25" y="212" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5AI-Hs-B6b">
-                                        <rect key="frame" x="70" y="180" width="181" height="34"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5AI-Hs-B6b">
+                                        <rect key="frame" x="70" y="212" width="186" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dsa-VP-cul">
-                                        <rect key="frame" x="20" y="224" width="291" height="2"/>
+                                        <rect key="frame" x="20" y="241" width="291" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="2" id="264-9P-auR"/>
+                                            <constraint firstAttribute="height" constant="1" id="264-9P-auR"/>
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Ex-CB-joa">
-                                        <rect key="frame" x="246" y="262" width="60" height="40"/>
+                                        <rect key="frame" x="251" y="272" width="60" height="40"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="60" id="Ajc-GZ-0EE"/>
-                                            <constraint firstAttribute="height" constant="40" id="nxg-u1-Nbk"/>
+                                            <constraint firstAttribute="height" constant="40" id="4tL-vr-Gyb"/>
+                                            <constraint firstAttribute="width" constant="60" id="np8-oC-5aE"/>
                                         </constraints>
                                         <state key="normal" title="저장">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1395,22 +1401,25 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rui-Cw-Szp">
-                                        <rect key="frame" x="25" y="272" width="39" height="30"/>
+                                        <rect key="frame" x="20" y="282" width="39" height="30"/>
                                         <state key="normal" title="초기화"/>
                                         <connections>
                                             <action selector="resetButtonDidTouch:" destination="osP-Rb-Pic" eventType="touchUpInside" id="VYA-F1-sYp"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bfg-WZ-3hI">
-                                        <rect key="frame" x="266" y="178" width="40" height="40"/>
+                                        <rect key="frame" x="271" y="198" width="35" height="35"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="40" id="Pug-rE-2ii"/>
-                                            <constraint firstAttribute="height" constant="40" id="wbe-PP-dMr"/>
+                                            <constraint firstAttribute="width" secondItem="Bfg-WZ-3hI" secondAttribute="height" id="DeC-yN-TZ9"/>
+                                            <constraint firstAttribute="width" constant="35" id="Pug-rE-2ii"/>
                                         </constraints>
-                                        <state key="normal" image="gobackward" catalog="system"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" image="gobackward" catalog="system">
+                                            <color key="titleColor" systemColor="labelColor"/>
+                                        </state>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                                <real key="value" value="2"/>
+                                                <real key="value" value="0.0"/>
                                             </userDefinedRuntimeAttribute>
                                             <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
                                                 <color key="value" systemColor="linkColor"/>
@@ -1424,20 +1433,20 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label preview" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Uz-L4-Vqi" customClass="PaddedLabel" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="65" y="17" width="105.5" height="20.5"/>
+                                        <rect key="frame" x="65" y="21.5" width="91.5" height="17"/>
                                         <color key="backgroundColor" red="0.46540110128754553" green="0.65010450326883662" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="paddingWidth">
-                                                <real key="value" value="5"/>
+                                                <real key="value" value="14"/>
                                             </userDefinedRuntimeAttribute>
                                             <userDefinedRuntimeAttribute type="number" keyPath="paddingHeight">
-                                                <real key="value" value="5"/>
+                                                <real key="value" value="8"/>
                                             </userDefinedRuntimeAttribute>
                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                <real key="value" value="5"/>
+                                                <real key="value" value="10"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                     </label>
@@ -1448,38 +1457,38 @@
                                     <constraint firstAttribute="trailing" secondItem="R2S-uP-pJN" secondAttribute="trailing" constant="20" id="1eP-Y3-6Hz"/>
                                     <constraint firstAttribute="trailing" secondItem="Bfg-WZ-3hI" secondAttribute="trailing" constant="25" id="2ed-LY-VrE"/>
                                     <constraint firstItem="5AI-Hs-B6b" firstAttribute="leading" secondItem="dTZ-Iv-3o8" secondAttribute="trailing" constant="15" id="3F5-cl-FOk"/>
-                                    <constraint firstItem="k9l-4u-0H2" firstAttribute="top" secondItem="DBb-Db-8Hr" secondAttribute="bottom" constant="15" id="3wr-bI-QxA"/>
-                                    <constraint firstItem="dsa-VP-cul" firstAttribute="top" secondItem="dTZ-Iv-3o8" secondAttribute="bottom" constant="15" id="6jn-fU-X0E"/>
+                                    <constraint firstItem="k9l-4u-0H2" firstAttribute="top" secondItem="DBb-Db-8Hr" secondAttribute="bottom" constant="30" id="4p5-fm-Ft2"/>
+                                    <constraint firstItem="5AI-Hs-B6b" firstAttribute="centerY" secondItem="dTZ-Iv-3o8" secondAttribute="centerY" id="7F7-hK-vtw"/>
                                     <constraint firstAttribute="trailing" secondItem="VcW-gJ-uC5" secondAttribute="trailing" id="AqQ-iE-up3"/>
-                                    <constraint firstItem="DBb-Db-8Hr" firstAttribute="top" secondItem="IUh-Op-b4p" secondAttribute="bottom" constant="15" id="Dr8-Zt-bmP"/>
-                                    <constraint firstAttribute="bottom" secondItem="Rui-Cw-Szp" secondAttribute="bottom" constant="25" id="M0v-7N-YIi"/>
+                                    <constraint firstItem="dsa-VP-cul" firstAttribute="top" secondItem="5AI-Hs-B6b" secondAttribute="bottom" constant="8" id="BS5-PV-Vmz"/>
+                                    <constraint firstItem="DBb-Db-8Hr" firstAttribute="top" secondItem="hdK-Cl-gN9" secondAttribute="bottom" constant="8" id="JdL-TW-X8w"/>
+                                    <constraint firstAttribute="bottom" secondItem="0Ex-CB-joa" secondAttribute="bottom" constant="15" id="KHP-uz-DLa"/>
+                                    <constraint firstItem="YzO-03-Taz" firstAttribute="leading" secondItem="k9l-4u-0H2" secondAttribute="trailing" constant="15" id="KtT-na-lIx"/>
+                                    <constraint firstAttribute="bottom" secondItem="Rui-Cw-Szp" secondAttribute="bottom" constant="15" id="M0v-7N-YIi"/>
                                     <constraint firstItem="lNG-AP-Ykp" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="15" id="MWl-Lw-ntv"/>
-                                    <constraint firstItem="k9l-4u-0H2" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="25" id="N2n-6f-urU"/>
-                                    <constraint firstItem="Rui-Cw-Szp" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="25" id="Neq-Qw-tgG"/>
+                                    <constraint firstItem="Rui-Cw-Szp" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="20" id="Neq-Qw-tgG"/>
                                     <constraint firstAttribute="trailing" secondItem="dsa-VP-cul" secondAttribute="trailing" constant="20" id="OzR-7L-tbu"/>
-                                    <constraint firstItem="R2S-uP-pJN" firstAttribute="top" secondItem="k9l-4u-0H2" secondAttribute="bottom" constant="15" id="Pre-d8-9iN"/>
-                                    <constraint firstItem="5AI-Hs-B6b" firstAttribute="top" secondItem="R2S-uP-pJN" secondAttribute="bottom" constant="12" id="Qci-WV-g04"/>
-                                    <constraint firstItem="DBb-Db-8Hr" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="20" id="RWI-8t-T1m"/>
-                                    <constraint firstItem="YzO-03-Taz" firstAttribute="leading" secondItem="k9l-4u-0H2" secondAttribute="trailing" constant="15" id="RjH-6E-ZK3"/>
+                                    <constraint firstItem="DBb-Db-8Hr" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="20" id="QNI-Te-ROD"/>
                                     <constraint firstAttribute="trailing" secondItem="hdK-Cl-gN9" secondAttribute="trailing" constant="25" id="Sh0-fp-TVt"/>
-                                    <constraint firstItem="dTZ-Iv-3o8" firstAttribute="top" secondItem="R2S-uP-pJN" secondAttribute="bottom" constant="20" id="Ucu-nO-xOh"/>
+                                    <constraint firstItem="1Uz-L4-Vqi" firstAttribute="centerY" secondItem="lNG-AP-Ykp" secondAttribute="centerY" id="Tff-bA-Oip"/>
+                                    <constraint firstItem="YzO-03-Taz" firstAttribute="centerY" secondItem="k9l-4u-0H2" secondAttribute="centerY" id="UIu-CB-fWU"/>
+                                    <constraint firstItem="dTZ-Iv-3o8" firstAttribute="top" secondItem="R2S-uP-pJN" secondAttribute="bottom" constant="30" id="Ucu-nO-xOh"/>
                                     <constraint firstItem="lNG-AP-Ykp" firstAttribute="top" secondItem="tFB-VW-lW9" secondAttribute="top" constant="15" id="VmG-Mk-98J"/>
                                     <constraint firstItem="dsa-VP-cul" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="20" id="WJe-IM-LPP"/>
-                                    <constraint firstItem="1Uz-L4-Vqi" firstAttribute="top" secondItem="tFB-VW-lW9" secondAttribute="top" constant="17" id="Wfz-x9-9F3"/>
-                                    <constraint firstAttribute="trailing" secondItem="0Ex-CB-joa" secondAttribute="trailing" constant="25" id="a0c-J6-mmZ"/>
+                                    <constraint firstItem="k9l-4u-0H2" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="25" id="Y3c-m4-dgS"/>
+                                    <constraint firstItem="Bfg-WZ-3hI" firstAttribute="bottom" secondItem="5AI-Hs-B6b" secondAttribute="bottom" id="YX1-Ek-grq"/>
+                                    <constraint firstAttribute="trailing" secondItem="0Ex-CB-joa" secondAttribute="trailing" constant="20" id="aE8-0a-1IJ"/>
+                                    <constraint firstItem="hdK-Cl-gN9" firstAttribute="centerY" secondItem="IUh-Op-b4p" secondAttribute="centerY" id="dzL-Fx-Yof"/>
                                     <constraint firstItem="hdK-Cl-gN9" firstAttribute="leading" secondItem="IUh-Op-b4p" secondAttribute="trailing" constant="15" id="eIw-L3-gKt"/>
                                     <constraint firstAttribute="trailing" secondItem="YzO-03-Taz" secondAttribute="trailing" constant="25" id="fBj-j5-QzZ"/>
                                     <constraint firstItem="VcW-gJ-uC5" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" id="jWU-cz-aNX"/>
-                                    <constraint firstItem="IUh-Op-b4p" firstAttribute="top" secondItem="VcW-gJ-uC5" secondAttribute="bottom" constant="15" id="jgc-Aa-ahY"/>
-                                    <constraint firstItem="Bfg-WZ-3hI" firstAttribute="top" secondItem="R2S-uP-pJN" secondAttribute="bottom" constant="10" id="jqK-ip-igx"/>
-                                    <constraint firstItem="DBb-Db-8Hr" firstAttribute="top" secondItem="hdK-Cl-gN9" secondAttribute="bottom" constant="8" id="kXI-yt-ZiW"/>
+                                    <constraint firstItem="IUh-Op-b4p" firstAttribute="top" secondItem="VcW-gJ-uC5" secondAttribute="bottom" constant="30" id="jgc-Aa-ahY"/>
                                     <constraint firstItem="1Uz-L4-Vqi" firstAttribute="leading" secondItem="lNG-AP-Ykp" secondAttribute="trailing" constant="20" id="oil-xt-h5g"/>
                                     <constraint firstItem="dTZ-Iv-3o8" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="25" id="pof-iW-XBp"/>
                                     <constraint firstItem="Bfg-WZ-3hI" firstAttribute="leading" secondItem="5AI-Hs-B6b" secondAttribute="trailing" constant="15" id="pwB-dH-d0G"/>
-                                    <constraint firstAttribute="bottom" secondItem="0Ex-CB-joa" secondAttribute="bottom" constant="25" id="pxu-RU-HbY"/>
+                                    <constraint firstAttribute="trailing" secondItem="DBb-Db-8Hr" secondAttribute="trailing" constant="20" id="qLu-Ie-RBK"/>
                                     <constraint firstItem="IUh-Op-b4p" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="25" id="tAc-Lf-mR6"/>
                                     <constraint firstItem="VcW-gJ-uC5" firstAttribute="top" secondItem="lNG-AP-Ykp" secondAttribute="bottom" constant="15" id="tVa-Jn-ejE"/>
-                                    <constraint firstAttribute="trailing" secondItem="DBb-Db-8Hr" secondAttribute="trailing" constant="20" id="v8I-9h-9mI"/>
                                     <constraint firstItem="R2S-uP-pJN" firstAttribute="leading" secondItem="tFB-VW-lW9" secondAttribute="leading" constant="20" id="yOE-7V-UUU"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
@@ -1888,7 +1897,7 @@
     </scenes>
     <designables>
         <designable name="1Uz-L4-Vqi">
-            <size key="intrinsicContentSize" width="105.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="91.5" height="17"/>
         </designable>
         <designable name="86J-Hv-DQh">
             <size key="intrinsicContentSize" width="48.5" height="17"/>
@@ -1897,7 +1906,7 @@
             <size key="intrinsicContentSize" width="98" height="17"/>
         </designable>
         <designable name="Xlb-je-POt">
-            <size key="intrinsicContentSize" width="41.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="31.5" height="14.5"/>
         </designable>
         <designable name="g0Z-SK-H5B">
             <size key="intrinsicContentSize" width="66" height="17"/>
@@ -1912,6 +1921,7 @@
         <image name="emoticon" width="64" height="64"/>
         <image name="gobackward" catalog="system" width="121" height="128"/>
         <image name="newIssue" width="64" height="64"/>
+        <image name="plus" catalog="system" width="128" height="113"/>
         <image name="plus.app.fill" catalog="system" width="128" height="114"/>
         <image name="up" width="64" height="64"/>
         <namedColor name="openIssue Background Color">

--- a/iOS/IssueTracker/IssueTracker/Extension/UIColor+Extension.swift
+++ b/iOS/IssueTracker/IssueTracker/Extension/UIColor+Extension.swift
@@ -9,8 +9,24 @@ import Foundation
 import UIKit
 
 extension UIColor {
+    
+    var redValue: CGFloat { return CIColor(color: self).red }
+    var greenValue: CGFloat { return CIColor(color: self).green }
+    var blueValue: CGFloat { return CIColor(color: self).blue }
+    var alphaValue: CGFloat { return CIColor(color: self).alpha }
+    
+    var textColor: UIColor {
+        let luminance = self.redValue * 0.299 + self.greenValue * 0.587 + self.blueValue * 0.114
+        if luminance < 0.5 {
+            return .white
+        } else {
+            return .black
+        }
+    }
+    
     //HexString to UIColor
     public convenience init?(hex: String) {
+        
         let red: CGFloat
         let green: CGFloat
         let blue: CGFloat

--- a/iOS/IssueTracker/IssueTracker/Label/View/LabelCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Label/View/LabelCollectionViewCell.swift
@@ -20,9 +20,14 @@ class LabelCollectionViewCell: UICollectionViewListCell {
     }
     
     func initLabelCell(label: Label) {
+        
         DispatchQueue.main.async { [weak self] in
+            
+            let backgroundColor = UIColor(hex: label.color)
             self?.nameLabel.text = label.labelName
-            self?.nameLabel.backgroundColor = UIColor(hex: label.color)
+            self?.nameLabel.backgroundColor = backgroundColor
+            self?.nameLabel.textColor = backgroundColor?.textColor
+            
             self?.descriptionLabel.text = label.description
         }
     }

--- a/iOS/IssueTracker/IssueTracker/Label/ViewController/LabelEditViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Label/ViewController/LabelEditViewController.swift
@@ -81,6 +81,7 @@ class LabelEditViewController: UIViewController {
         }
         DispatchQueue.main.async { [weak self] in
             self?.labelPreviewLabel.backgroundColor = labelColor
+            self?.labelPreviewLabel.textColor = labelColor.textColor
             self?.randomColorButton.backgroundColor = labelColor
             self?.colorTextField.text = labelColor.toHexString()
         }

--- a/iOS/IssueTracker/IssueTracker/Label/ViewController/LabelViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Label/ViewController/LabelViewController.swift
@@ -35,6 +35,7 @@ class LabelViewController: UIViewController {
         let dataSource = LabelDataSource(
             collectionView: labelCollectionView,
             cellProvider: { (collectionView, indexPath, label) -> UICollectionViewCell? in
+                
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LabelCollectionViewCell.reuseIdentifier, for: indexPath)
                     as? LabelCollectionViewCell else { return UICollectionViewCell() }
             cell.initLabelCell(label: label)
@@ -45,6 +46,7 @@ class LabelViewController: UIViewController {
     }
     
     private func createCollectionViewLayout() -> UICollectionViewLayout {
+        
         var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
         configuration.trailingSwipeActionsConfigurationProvider = { [unowned self] (indexPath) in
             
@@ -52,13 +54,14 @@ class LabelViewController: UIViewController {
                 NetworkManager.shared.deleteRequest(
                     url: .label,
                     deleteID: self.labels[indexPath.row].labelId) { (nsDictionary) in
-                    print(nsDictionary)
+                    
                     NotificationCenter.default.post(name: .labelDidChange, object: nil)
                 }
                 completion(true)
             }
             deleteAction.backgroundColor = .systemPink
             deleteAction.image = UIImage(named: "delete")?.withTintColor(UIColor.white)
+            
             return UISwipeActionsConfiguration(actions: [deleteAction])
         }
         
@@ -66,6 +69,7 @@ class LabelViewController: UIViewController {
     }
     
     @objc func reloadLabels() {
+        
         DispatchQueue.main.async {
             NetworkManager.shared.getRequest(url: .label, type: LabelArray.self) { result in
                 guard let labelArray = result else { return }
@@ -78,8 +82,10 @@ class LabelViewController: UIViewController {
         }
     }
     
-    @IBAction func addButtonDidTouch(_ sender: Any) {
+    @IBAction func addButtonDidTouch(_ sender: UIButton) {
+        
         if let editVC = self.storyboard?.instantiateViewController(identifier: LabelEditViewController.reuseIdentifier) as? LabelEditViewController {
+            
             editVC.modalPresentationStyle = .overFullScreen
             editVC.modalTransitionStyle = .crossDissolve
             editVC.initEditView(isNew: true, label: nil)
@@ -93,9 +99,12 @@ class LabelViewController: UIViewController {
 }
 
 extension LabelViewController: UICollectionViewDelegate {
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
         if let editVC = self.storyboard?.instantiateViewController(identifier: LabelEditViewController.reuseIdentifier)
             as? LabelEditViewController {
+            
             editVC.modalPresentationStyle = .overFullScreen
             editVC.modalTransitionStyle = .crossDissolve
             self.present(editVC, animated: true, completion: nil)

--- a/iOS/IssueTracker/IssueTracker/Milestone/View/MilestoneCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Milestone/View/MilestoneCollectionViewCell.swift
@@ -26,9 +26,11 @@ class MilestoneCollectionViewCell: UICollectionViewListCell {
     }
     
     func initMilestoneCell(milestone: Milestone) {
+        
         DispatchQueue.main.async { [weak self] in
             self?.titleLabel.text = milestone.title
-            self?.dueDateLabel.text = milestone.dueDate
+            let dueDate = milestone.dueDate.split(separator: "-")
+            self?.dueDateLabel.text = "\(dueDate[0])년 \(dueDate[1])월 \(dueDate[2])일까지"
             self?.contentLabel.text = milestone.content
         }
     }


### PR DESCRIPTION
# 제목
레이블 및 마일스톤 화면 수정

## 관련 이슈 및 위키
- 이슈 : 
- 위키 : 

## 내용
- 전반적인 레이블 및 마일스톤 UI 화면 수정
- 레이블의 경우, 배경 색에 따라 텍스트 색상을 변경 가능하도록 수정
- edit 화면에서 작성 글이 길어질 때, 앞에 라벨이 밀리는 현상 보완
- 키보드 올려도 edit 화면 길이가 길어지지 않음
- 문제점
: 마일스톤 화면에서 타이틀이 길어질 때, 상단 라벨들이 겹치는 문제가 있음

<img width="876" alt="스크린샷 2020-11-09 오후 5 40 16" src="https://user-images.githubusercontent.com/28432479/98518474-c8018d00-22b2-11eb-801f-31911037e68e.png">
<img width="767" alt="스크린샷 2020-11-09 오후 5 41 08" src="https://user-images.githubusercontent.com/28432479/98518488-cb951400-22b2-11eb-9476-34f6ff7bbaf3.png">

## Why?
