### PR TITLE
[feat] 레이블 배지 추가 및 open close 기능 추가

### DIFF
--- a/web-FE/src/api/issue.js
+++ b/web-FE/src/api/issue.js
@@ -10,3 +10,14 @@ export const getAllIssues = async () => {
     console.error(error);
   }
 };
+
+export const updateIsOpen = (issueIdList, isOpen) => {
+  try {
+    issueIdList.forEach((issueId) => {
+      const url = `/api/issue/${issueId}/isopen`;
+      instance.patch(url, { is_open: isOpen });
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/web-FE/src/components/Issue/ActionDropdown.jsx
+++ b/web-FE/src/components/Issue/ActionDropdown.jsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import styled from 'styled-components';
+import Dropdown from '../commons/Dropdown';
+
+const ActionDropdown = ({className, action, selected}) => {
+  const title = 'Mark as';
+  const list = [
+    { title: 'Open', id: 1 },
+    { title: 'Close', id: 2 },
+  ];
+  const setSelect = (id) => {
+    const selectedList = Object.values(selected);
+    if (id === 1) {
+      action({ type: 'OPEN', data: selectedList });
+    } else if (id === 2) {
+      console.log(selected);
+      action({ type: 'CLOSE', data: selectedList });
+    }
+  }
+  return (
+    <Dropdown
+      className={className}
+      title={title}
+      list={list}
+      action={action}
+      setSelect={setSelect}
+    />
+  )
+}
+
+const StyledActionDropdown = styled(ActionDropdown)`
+  margin-right: 10px;
+`;
+
+export default StyledActionDropdown;

--- a/web-FE/src/components/Issue/IssueListBoard.jsx
+++ b/web-FE/src/components/Issue/IssueListBoard.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import { IssueContext } from '@Stores/IssueStore';
 import IssueListHeader from './IssueListHeader';
@@ -7,16 +7,24 @@ import { IssueFilterContext } from '@Stores/IssueFilterStore';
 import filter from '@Services/issue/filter';
 
 const IssueListBoard = () => {
-  const {issueState} = useContext(IssueContext);
+  const {issueState, dispatch} = useContext(IssueContext);
   const {filterState} = useContext(IssueFilterContext);
+  const [selected, setSelected] = useState({});
   const filteredIssues = filter(issueState, filterState);
-  console.log(filteredIssues);
+  console.log(selected);
   return (
     <Board>
-      <IssueListHeader />
+      <IssueListHeader selected={selected} action={dispatch}/>
       {filteredIssues.map((issue) => {
         const { issue_id: issueId } = issue;
-        return (<IssueListItem issue={issue} key={issueId} />);
+        return (
+          <IssueListItem
+            issue={issue}
+            key={issueId}
+            selected={selected}
+            setSelected={setSelected} 
+          />
+        );
       })}
     </Board>
   );

--- a/web-FE/src/components/Issue/IssueListHeader.jsx
+++ b/web-FE/src/components/Issue/IssueListHeader.jsx
@@ -1,21 +1,50 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import Dropdown from '../commons/Dropdown';
+import ActionDropdown from '@Components/Issue/ActionDropdown';
 import { IssueAssigneeFilter, IssueAuthorFilter, IssueLabelFilter, IssueMilestoneFilter } from './Filters';
 
-const IssueListBoard = () => (
-  <FlexRowDiv>
-    <Checkbox>
-      <input type="checkbox" name="check-all" />
-    </Checkbox>
-    <FilterContainer>
-      <IssueAuthorFilter />
-      <IssueLabelFilter />
-      <IssueMilestoneFilter />
-      <IssueAssigneeFilter />
-    </FilterContainer>
-  </FlexRowDiv>
-);
+const IssueListBoard = ({ selected, action }) => {
+  const selectedNum = Object.keys(selected).length;
+  return (
+    <FlexRowDiv>
+      <Checkbox>
+        <input type="checkbox" name="check-all" />
+      </Checkbox>
+      {
+        selectedNum ?
+          (
+            <>
+              <SelectedIndicator>
+                {selectedNum}
+                {' '}
+                selected
+              </SelectedIndicator>
+              <FilterContainer>
+                <ActionDropdown
+                  className="action-dropdown"
+                  action={action}
+                  selected={selected}
+                />
+              </FilterContainer>
+            </>
+          )
+          : (
+            <FilterContainer>
+              <IssueAuthorFilter />
+              <IssueLabelFilter />
+              <IssueMilestoneFilter />
+              <IssueAssigneeFilter />
+            </FilterContainer>
+          )
+      }
+    </FlexRowDiv>
+  );
+}
+
+const SelectedIndicator = styled.span`
+    color: grey;
+    margin-left: 20px;
+`;
 
 const FlexRowDiv = styled.div`
   display:flex;
@@ -36,10 +65,6 @@ const FilterContainer = styled.div`
 const Checkbox = styled.label`
   display: block;
   padding: 8px 0 8px 16px;
-`;
-
-const IssueFilter = styled(Dropdown)`
-  margin-right: 30px;
 `;
 
 export default IssueListBoard;

--- a/web-FE/src/components/Issue/IssueListItem.jsx
+++ b/web-FE/src/components/Issue/IssueListItem.jsx
@@ -1,8 +1,8 @@
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import OpenCloseIndicator from './OpenCloseIndicator';
+import LabelBadge from '@Components/commons/LabelBadge';
 
 const IssueListItem = (props) => {
   const { issue } = props;
@@ -13,21 +13,34 @@ const IssueListItem = (props) => {
     write_time: writeTime,
     is_open: isOpen,
     writer,
+    labels,
   } = issue;
   const issueInfo = `#${issueId} opened at ${writeTime} by ${writer}`;
   return (
-    <FlexRowDiv>
+    <ItemContainer>
       <Checkbox>
         <input type="checkbox" name="check-all" />
       </Checkbox>
       <OpenCloseIndicator isOpen={isOpen} />
       <IssueContent>
-        <IssueTitle to="/">{title}</IssueTitle>
+        <FlexRowDiv>
+          <IssueTitle to="/">{title}</IssueTitle>
+          <>
+            {labels.map((label) => (
+              <LabelBadge
+                key={label.label_id}
+                color={label.color}
+                name={label.label_name}
+                margin="0 0 0 10px"
+              />
+            ))}
+          </>
+        </FlexRowDiv>
         <IssueInfo>
           {issueInfo}
         </IssueInfo>
       </IssueContent>
-    </FlexRowDiv>
+    </ItemContainer>
   );
 };
 
@@ -35,6 +48,10 @@ const FlexRowDiv = styled.div`
   display:flex;
   flex-direction: row;
   align-items: center;
+  
+`;
+
+const ItemContainer = styled(FlexRowDiv)`
   height: 50px;
   border-right: 1px solid #e1e4e8;
   border-left: 1px solid #e1e4e8;

--- a/web-FE/src/components/Issue/IssueListItem.jsx
+++ b/web-FE/src/components/Issue/IssueListItem.jsx
@@ -5,7 +5,7 @@ import OpenCloseIndicator from './OpenCloseIndicator';
 import LabelBadge from '@Components/commons/LabelBadge';
 
 const IssueListItem = (props) => {
-  const { issue } = props;
+  const { issue, selected, setSelected } = props;
 
   const {
     issue_id: issueId,
@@ -16,10 +16,18 @@ const IssueListItem = (props) => {
     labels,
   } = issue;
   const issueInfo = `#${issueId} opened at ${writeTime} by ${writer}`;
+  const onCheckBoxChange = (e) => {
+    if (selected[issueId]) {
+      const { [issueId]: id, ...rest } = selected;
+      setSelected(rest);
+      return;
+    }
+    setSelected({ ...selected, [issueId]: issueId });
+  };
   return (
     <ItemContainer>
       <Checkbox>
-        <input type="checkbox" name="check-all" />
+        <input type="checkbox" name="check-all" onChange={onCheckBoxChange}/>
       </Checkbox>
       <OpenCloseIndicator isOpen={isOpen} />
       <IssueContent>

--- a/web-FE/src/components/Label/index.jsx
+++ b/web-FE/src/components/Label/index.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import PageLayout from '@Common/PageLayout';
 import Header from '@Common/Header';
 import LabelStore from '@Stores/LabelStore';
+import MilestoneStore from '@Stores/MilestoneStore';
 import LabelMain from './LabelMain';
 
 const LabelPage = () => (
-  <LabelStore>
-    <PageLayout header={<Header page="Label" />} main={<LabelMain />} />
-  </LabelStore>
+  <MilestoneStore>
+    <LabelStore>
+      <PageLayout header={<Header page="Label" />} main={<LabelMain />} />
+    </LabelStore>
+  </MilestoneStore>
 );
 export default LabelPage;

--- a/web-FE/src/components/commons/ButtonWithIcon.jsx
+++ b/web-FE/src/components/commons/ButtonWithIcon.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const ButtonWithIcon = ({
-  image, name, number, className,
+  image, name, number, className, to
 }) => (
   <>
-    <Button className={className}>
+    <Button className={className} to={to}>
       <Img src={image} />
       {name}
       <NumberIndicator>
@@ -15,10 +16,13 @@ const ButtonWithIcon = ({
   </>
 );
 
-const Button = styled.a`
+const Button = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor:pointer;
+  text-decoration:none;
+  color:black;
 `;
 
 const NumberIndicator = styled.span`
@@ -26,14 +30,15 @@ const NumberIndicator = styled.span`
   font-size: 12px;
   font-weight: 500;
   text-align: center;
-  border: 1px solid transparent;
   border-radius: 2em;
+  background-color: lightgrey;
+  margin-left: 5px;
 `;
 
 const Img = styled.img`
   height:20px;
   width:20px;
-  margin-right: 2px;
+  margin-right: 5px;
 `;
 
 export default ButtonWithIcon;

--- a/web-FE/src/components/commons/LabelBadge.jsx
+++ b/web-FE/src/components/commons/LabelBadge.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 const LabelBadge = (props) => {
-  const { name, color } = props;
+  const { name, color, margin } = props;
   return (
-    <Badge backgroundColor={color}>{name}</Badge>
+    <Badge backgroundColor={color} margin={margin}>{name}</Badge>
   );
 };
 
@@ -21,6 +21,7 @@ const Badge = styled.div`
   -webkit-appearance: none;
   height:20px;
   align-items:center;
+  ${(props) => `margin:${props.margin};`}
 `;
 
 export default LabelBadge;

--- a/web-FE/src/components/commons/LabelMilestoneTag.jsx
+++ b/web-FE/src/components/commons/LabelMilestoneTag.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import labelIcon from '@Images/label.svg';
 import milestoneIcon from '@Images/milestone.svg';
 import ButtonWithIcon from './ButtonWithIcon';
+import {MilestoneContext} from '@Stores/MilestoneStore';
+import {LabelContext} from '@Stores/LabelStore';
 
 const goTo = (e) => {
   const targetButton = e.target.closest('.tag');
@@ -14,39 +16,44 @@ const goTo = (e) => {
   location.href = '/';
 };
 
-const App = () => (
-  <Div onClick={goTo}>
-    <LabelButton
-      className="tag label-button"
-      image={labelIcon}
-      name="label"
-      number="3"
-    />
-    <MilestoneButton
-      className="tag milestone-button"
-      image={milestoneIcon}
-      name="milestone"
-      number="3"
-    />
-  </Div>
-);
+const App = () => {
+  const {milestoneState} = useContext(MilestoneContext);
+  const {labelState} = useContext(LabelContext);
+  return (
+    <Div onClick={goTo}>
+      <LabelButton
+        className="tag label-button"
+        image={labelIcon}
+        name="label"
+        number={milestoneState.length}
+        to="/label"
+      />
+      <MilestoneButton
+        className="tag milestone-button"
+        image={milestoneIcon}
+        name="milestone"
+        number={labelState.length}
+        to="/milestone"
+      />
+    </Div>
+  );
+}
 
 const common = `
   height: 35px;
   box-sizing: border-box;
   border: 1px solid lightgrey;
+  padding: 0 10px;
 `;
 
 const LabelButton = styled(ButtonWithIcon)`
   ${common}
   border-radius: 5px 0 0 5px;
-  padding-left: 3px;
 `;
 
 const MilestoneButton = styled(ButtonWithIcon)`
   ${common}
   border-radius: 0 5px 5px 0;
-  padding-right: 3px;
 `;
 
 const Div = styled.div`

--- a/web-FE/src/components/commons/LabelMilestoneTag.jsx
+++ b/web-FE/src/components/commons/LabelMilestoneTag.jsx
@@ -25,14 +25,14 @@ const App = () => {
         className="tag label-button"
         image={labelIcon}
         name="label"
-        number={milestoneState.length}
+        number={labelState.length}
         to="/label"
       />
       <MilestoneButton
         className="tag milestone-button"
         image={milestoneIcon}
         name="milestone"
-        number={labelState.length}
+        number={milestoneState.length}
         to="/milestone"
       />
     </Div>

--- a/web-FE/src/stores/IssueStore.jsx
+++ b/web-FE/src/stores/IssueStore.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 import React, { useEffect, useReducer } from 'react';
-import { getAllIssues } from '@Api/issue';
+import { getAllIssues, updateIsOpen } from '@Api/issue';
 
 export const IssueContext = React.createContext();
 
@@ -12,6 +12,18 @@ const issueReducer = (issueState, { type, data }) => {
       return [...issueState, data];
     case 'UPDATE':
       return issueState.map((issue) => (issue.issue_id === data.issue_id ? data : issue));
+    case 'CLOSE':
+      updateIsOpen(data, false);
+      return issueState.map((issue) => (
+        data.includes(issue.issue_id)
+          ? { ...issue, is_open: false }
+          : issue));
+    case 'OPEN':
+      updateIsOpen(data, true);
+      return issueState.map((issue) => (
+        data.includes(issue.issue_id)
+          ? { ...issue, is_open: true }
+          : issue));
     default:
       return issueState;
   }


### PR DESCRIPTION
# [feat] 레이블 배지 추가 및 open close 기능 추가
## 관련 이슈 및 위키
## 내용
1. 레이블 배지를 추가했습니다.
2. 상단 레이블 버튼에 링크를 넣어 url 이동을 하도록 했습니다.
3. 마일스톤, 레이블 버튼에 숫자를 데이터를 받아 반영하도록 했습니다.
4. 이슈를 체크하면 헤더가 달라지도록 했습니다.
5. 체크 후 open/close 기능을 추가했습니다.
